### PR TITLE
Manage checked menu item state

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ function clicked(event: MouseEvent) {
   if (item) commit(item, details)
 }
 
-function isCheckable(el: Element) {
+function isCheckable(el: Element): boolean {
   const role = el.getAttribute('role')
   return role === 'menuitemradio' || role === 'menuitemcheckbox'
 }

--- a/index.js
+++ b/index.js
@@ -75,8 +75,8 @@ function clicked(event: MouseEvent) {
 }
 
 function updateChecked(selected: Element, details: Element) {
-  if (!selected.hasAttribute('aria-checked')) return
-  for (const el of details.querySelectorAll('[role="menuitem"][aria-checked]')) {
+  if (selected.getAttribute('role') !== 'menuitemradio') return
+  for (const el of details.querySelectorAll('[role="menuitemradio"]')) {
     el.setAttribute('aria-checked', 'false')
   }
   selected.setAttribute('aria-checked', 'true')

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function focusInput(details: Element) {
 }
 
 function sibling(details: Element, next: boolean): HTMLElement {
-  const options = Array.from(details.querySelectorAll('[role="menuitem"]:not([hidden])'))
+  const options = Array.from(details.querySelectorAll('[role^="menuitem"]:not([hidden])'))
   const selected = document.activeElement
   const index = options.indexOf(selected)
   const sibling = next ? options[index + 1] : options[index - 1]
@@ -70,7 +70,7 @@ function clicked(event: MouseEvent) {
   // Ignore clicks from nested details.
   if (target.closest('details') !== details) return
 
-  const item = target.closest('[role="menuitem"]')
+  const item = target.closest('[role^="menuitem"]')
   if (item) commit(item, details)
 }
 
@@ -124,7 +124,7 @@ function keydown(event: KeyboardEvent) {
     case 'Enter':
       {
         const selected = document.activeElement
-        if (selected && selected.getAttribute('role') === 'menuitem' && selected.closest('details') === details) {
+        if (selected && isMenuItem(selected) && selected.closest('details') === details) {
           event.preventDefault()
           event.stopPropagation()
           commit(selected, details)
@@ -133,6 +133,11 @@ function keydown(event: KeyboardEvent) {
       }
       break
   }
+}
+
+function isMenuItem(el: Element): boolean {
+  const role = el.getAttribute('role')
+  return role === 'menuitem' || role === 'menuitemcheckbox' || role === 'menuitemradio'
 }
 
 function close(details: Element) {

--- a/index.js
+++ b/index.js
@@ -74,10 +74,18 @@ function clicked(event: MouseEvent) {
   if (item) commit(item, details)
 }
 
+function isCheckable(el: Element) {
+  const role = el.getAttribute('role')
+  return role === 'menuitemradio' || role === 'menuitemcheckbox'
+}
+
 function updateChecked(selected: Element, details: Element) {
-  if (selected.getAttribute('role') !== 'menuitemradio') return
-  for (const el of details.querySelectorAll('[role="menuitemradio"]')) {
-    el.setAttribute('aria-checked', 'false')
+  if (!isCheckable(selected)) return
+
+  if (selected.getAttribute('role') === 'menuitemradio') {
+    for (const el of details.querySelectorAll('[role="menuitemradio"]')) {
+      el.setAttribute('aria-checked', 'false')
+    }
   }
   selected.setAttribute('aria-checked', 'true')
 }

--- a/index.js
+++ b/index.js
@@ -74,8 +74,17 @@ function clicked(event: MouseEvent) {
   if (item) commit(item, details)
 }
 
+function updateChecked(selected: Element, details: Element) {
+  if (!selected.hasAttribute('aria-checked')) return
+  for (const el of details.querySelectorAll('[role="menuitem"][aria-checked]')) {
+    el.setAttribute('aria-checked', 'false')
+  }
+  selected.setAttribute('aria-checked', 'true')
+}
+
 function commit(selected: Element, details: Element) {
   updateLabel(selected, details)
+  updateChecked(selected, details)
   close(details)
   selected.dispatchEvent(new CustomEvent('details-menu-selected', {bubbles: true}))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -19,9 +19,9 @@ describe('details-menu element', function() {
         <details>
           <summary data-menu-button>Click</summary>
           <details-menu>
-            <button type="button" role="menuitem" aria-checked="false" data-menu-button-text>Hubot</button>
-            <button type="button" role="menuitem" aria-checked="false">Bender</button>
-            <button type="button" role="menuitem" aria-checked="false">BB-8</button>
+            <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
+            <button type="button" role="menuitem">Bender</button>
+            <button type="button" role="menuitem">BB-8</button>
           </details-menu>
         </details>
       `
@@ -48,15 +48,6 @@ describe('details-menu element', function() {
       assert.equal(summary, document.activeElement, 'escape focuses summary')
     })
 
-    it('manages checked state', function() {
-      const details = document.querySelector('details')
-      const item = details.querySelector('button')
-      assert.equal(item.getAttribute('aria-checked'), 'false')
-      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
-      assert.equal(item.getAttribute('aria-checked'), 'true')
-      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
-    })
-
     it('updates the button label', function() {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')
@@ -64,6 +55,36 @@ describe('details-menu element', function() {
       assert.equal(summary.textContent, 'Click')
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(summary.textContent, 'Hubot')
+    })
+  })
+
+  describe('mutually exclusive menu items', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Click</summary>
+          <details-menu>
+            <button type="button" role="menuitemradio" aria-checked="false">Hubot</button>
+            <button type="button" role="menuitemradio" aria-checked="false">Bender</button>
+            <button type="button" role="menuitemradio" aria-checked="false">BB-8</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('manages checked state', function() {
+      const details = document.querySelector('details')
+      const item = details.querySelector('button')
+      assert.equal(item.getAttribute('aria-checked'), 'false')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(item.getAttribute('aria-checked'), 'true')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -17,9 +17,9 @@ describe('details-menu element', function() {
       const container = document.createElement('div')
       container.innerHTML = `
         <details>
-          <summary>Click</summary>
+          <summary data-menu-button>Click</summary>
           <details-menu>
-            <button type="button" role="menuitem" aria-checked="false">Hubot</button>
+            <button type="button" role="menuitem" aria-checked="false" data-menu-button-text>Hubot</button>
             <button type="button" role="menuitem" aria-checked="false">Bender</button>
             <button type="button" role="menuitem" aria-checked="false">BB-8</button>
           </details-menu>
@@ -55,6 +55,15 @@ describe('details-menu element', function() {
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
+    })
+
+    it('updates the button label', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const item = details.querySelector('button')
+      assert.equal(summary.textContent, 'Click')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(summary.textContent, 'Hubot')
     })
   })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -19,9 +19,9 @@ describe('details-menu element', function() {
         <details>
           <summary>Click</summary>
           <details-menu>
-            <button type="button" role="menuitem">Hubot</button>
-            <button type="button" role="menuitem">Bender</button>
-            <button type="button" role="menuitem">BB-8</button>
+            <button type="button" role="menuitem" aria-checked="false">Hubot</button>
+            <button type="button" role="menuitem" aria-checked="false">Bender</button>
+            <button type="button" role="menuitem" aria-checked="false">BB-8</button>
           </details-menu>
         </details>
       `
@@ -37,7 +37,7 @@ describe('details-menu element', function() {
       const summary = details.querySelector('summary')
 
       summary.focus()
-      summary.dispatchEvent(new MouseEvent('click'))
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(summary, document.activeElement, 'summary remains focused on toggle')
 
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown'}))
@@ -46,6 +46,15 @@ describe('details-menu element', function() {
 
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'Escape'}))
       assert.equal(summary, document.activeElement, 'escape focuses summary')
+    })
+
+    it('manages checked state', function() {
+      const details = document.querySelector('details')
+      const item = details.querySelector('button')
+      assert.equal(item.getAttribute('aria-checked'), 'false')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(item.getAttribute('aria-checked'), 'true')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
     })
   })
 })


### PR DESCRIPTION
Synchronize the `aria-checked` state of menu items when an item is selected. Also includes a test for the updating the button label with the selected item's text.