### PR TITLE
Change haspopup value to menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class DetailsMenuElement extends HTMLElement {
     if (!details) return
 
     const summary = details.querySelector('summary')
-    if (summary) summary.setAttribute('aria-haspopup', 'true')
+    if (summary) summary.setAttribute('aria-haspopup', 'menu')
 
     details.addEventListener('click', clicked)
     details.addEventListener('keydown', keydown)


### PR DESCRIPTION
It does default to `menu` but would be good to be explicit. 🙆 
https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup
