### PR TITLE
Support disabled menuitem 

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,8 @@ function updateChecked(selected: Element, details: Element) {
 }
 
 function commit(selected: Element, details: Element) {
+  if (selected.getAttribute('aria-disabled') === 'true') return
+
   updateLabel(selected, details)
   updateChecked(selected, details)
   close(details)

--- a/index.js
+++ b/index.js
@@ -64,7 +64,9 @@ function focusInput(details: Element) {
 }
 
 function sibling(details: Element, next: boolean): HTMLElement {
-  const options = Array.from(details.querySelectorAll('[role^="menuitem"]:not([hidden])'))
+  const options = Array.from(
+    details.querySelectorAll('[role^="menuitem"]:not([hidden]):not([disabled]):not([aria-disabled="true"])')
+  )
   const selected = document.activeElement
   const index = options.indexOf(selected)
   const sibling = next ? options[index + 1] : options[index - 1]

--- a/test/test.js
+++ b/test/test.js
@@ -76,9 +76,10 @@ describe('details-menu element', function() {
       summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp'}))
 
-      const disabled = details.querySelector('[aria-disabled="true"]')
-      assert.equal(disabled, document.activeElement, 'arrow focuses the disabled item')
+      const notDisabled = details.querySelectorAll('[role="menuitem"]')[2]
+      assert.equal(notDisabled, document.activeElement, 'arrow focuses on the last non-disabled item')
 
+      const disabled = details.querySelector('[aria-disabled="true"]')
       disabled.addEventListener('details-menu-selected', () => eventCounter++)
       disabled.dispatchEvent(new MouseEvent('click', {bubbles: true}))
 

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ describe('details-menu element', function() {
             <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
             <button type="button" role="menuitem" data-menu-button-contents><strong>Bender</strong></button>
             <button type="button" role="menuitem">BB-8</button>
+            <button type="button" role="menuitem" data-menu-button-text aria-disabled="true">WALL-E</button>
           </details-menu>
         </details>
       `
@@ -64,6 +65,25 @@ describe('details-menu element', function() {
       assert.equal(summary.textContent, 'Click')
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(summary.innerHTML, '<strong>Bender</strong>')
+    })
+
+    it('does not trigger disabled item', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      let eventCounter = 0
+
+      summary.focus()
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp'}))
+
+      const disabled = details.querySelector('[aria-disabled="true"]')
+      assert.equal(disabled, document.activeElement, 'arrow focuses the disabled item')
+
+      disabled.addEventListener('details-menu-selected', () => eventCounter++)
+      disabled.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+
+      assert.equal(eventCounter, 0, 'selected event is not fired')
+      assert(details.open, 'menu stays open')
     })
   })
 


### PR DESCRIPTION
This prevents items with `aria-disabled="true"` from being triggered.

@dgraham I noticed that the arrow navigation will get stuck because `button[disabled]` is not focusable. We will need to [filter out `[disabled]`](https://github.com/github/details-menu-element/blob/38bd3dc0af7934029b9e41c89fe3a317ef659c42/index.js#L67) to fix it. 

That makes me wonder if we should match this non-focusable behavior on `aria-disabled=true` items. This would mean not only filtering it out, but also requiring `tabindex="-1"` on `focusable[aria-disabled="true"]` items so it escapes <kbd>tab</kbd> focus. 

And then we will end up with 🤔 

```javascript
details.querySelectorAll('[role^="menuitem"]:not([hidden]):not([disabled]):not([aria-disabled="true"])')
```

What do you think?

This isn't a problem for `<auto-complete>` since it doesn't rely on the `:focus` state. 