### PR TITLE
Add details-menu-select and prevent closing on menuitemcheckbox click

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,9 @@ function updateChecked(selected: Element, details: Element) {
 function commit(selected: Element, details: Element) {
   if (selected.getAttribute('aria-disabled') === 'true') return
 
+  const dispatched = selected.dispatchEvent(new CustomEvent('details-menu-select', {bubbles: true, cancelable: true}))
+  if (!dispatched) return
+
   updateLabel(selected, details)
   updateChecked(selected, details)
   close(details)

--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function commit(selected: Element, details: Element) {
 
   updateLabel(selected, details)
   updateChecked(selected, details)
-  close(details)
+  if (selected.getAttribute('role') !== 'menuitemcheckbox') close(details)
   selected.dispatchEvent(new CustomEvent('details-menu-selected', {bubbles: true}))
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,39 @@ describe('details-menu element', function() {
     })
   })
 
+  describe('menu item checkboxes', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Click</summary>
+          <details-menu>
+            <button type="button" role="menuitemcheckbox" aria-checked="false">Hubot</button>
+            <button type="button" role="menuitemcheckbox" aria-checked="true">Bender</button>
+            <button type="button" role="menuitemcheckbox" aria-checked="false">BB-8</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('manages checked state and menu stays open', function() {
+      const details = document.querySelector('details')
+      const summary = document.querySelector('summary')
+      const item = details.querySelector('button')
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open, 'menu opens')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open, 'menu stays open')
+      assert.equal(item.getAttribute('aria-checked'), 'true')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 2)
+    })
+  })
+
   describe('opening the menu', function() {
     beforeEach(function() {
       const container = document.createElement('div')

--- a/test/test.js
+++ b/test/test.js
@@ -67,6 +67,52 @@ describe('details-menu element', function() {
       assert.equal(summary.innerHTML, '<strong>Bender</strong>')
     })
 
+    it('fires events in order', function(done) {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const item = details.querySelector('button')
+
+      item.addEventListener('details-menu-select', () => {
+        assert(details.open, 'menu is still open')
+        assert.equal(summary.textContent, 'Click')
+      })
+
+      item.addEventListener('details-menu-selected', () => {
+        assert(!details.open, 'menu is closed')
+        assert.equal(summary.textContent, 'Hubot')
+        done()
+      })
+
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open)
+    })
+
+    it('fires cancellable select event', function(done) {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const item = details.querySelector('button')
+      let selectedEventCounter = 0
+
+      item.addEventListener('details-menu-select', event => {
+        event.preventDefault()
+        assert(details.open, 'menu is still open')
+        assert.equal(summary.textContent, 'Click')
+        setTimeout(() => {
+          assert.equal(selectedEventCounter, 0, 'selected event is not fired')
+          done()
+        }, 0)
+      })
+
+      item.addEventListener('details-menu-selected', () => {
+        selectedEventCounter++
+      })
+
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open)
+    })
+
     it('does not trigger disabled item', function() {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')


### PR DESCRIPTION
- New cancellable `details-menu-select` event instead of changing the existing event for compatibility
- For `menuitemcheckbox` I think by default menu just shouldn't be closed