### PR TITLE
Prevent committing twice on keydown

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,6 @@ function keydown(event: KeyboardEvent) {
         if (selected && isMenuItem(selected) && selected.closest('details') === details) {
           event.preventDefault()
           event.stopPropagation()
-          commit(selected, details)
           selected.click()
         }
       }


### PR DESCRIPTION
I noticed that `details-menu-select` is being fired twice on <kbd>Enter/Space</kbd> `keydown` but not on click. In the <kbd>Enter/Space</kbd> handler we call `commit()`, and then `click()` which triggers another `commit()`. 

This removes the first `commit()` so whatever comes with the native click binding on the element still happens. For example <kbd>Space</kbd>(which by default doesn't trigger `<a>`) on `<a role="menuitem">` should navigate + `commit`, as a click would.

I tried to add a test case but couldn't simulate the native `Enter` event.