### PR TITLE
Fix exception thrown when no menu items are found

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function focusInput(details: Element) {
   }
 }
 
-function sibling(details: Element, next: boolean): HTMLElement {
+function sibling(details: Element, next: boolean): ?HTMLElement {
   const options = Array.from(
     details.querySelectorAll('[role^="menuitem"]:not([hidden]):not([disabled]):not([aria-disabled="true"])')
   )
@@ -124,28 +124,33 @@ function keydown(event: KeyboardEvent) {
   // Ignore key presses from nested details.
   if (details.querySelector('details[open]')) return
 
+  let target
   switch (event.key) {
     case 'Escape':
       close(details)
       event.preventDefault()
       break
     case 'ArrowDown':
-      sibling(details, true).focus()
+      target = sibling(details, true)
+      if (target) target.focus()
       event.preventDefault()
       break
     case 'ArrowUp':
-      sibling(details, false).focus()
+      target = sibling(details, false)
+      if (target) target.focus()
       event.preventDefault()
       break
     case 'n':
       if (ctrlBindings && event.ctrlKey) {
-        sibling(details, true).focus()
+        target = sibling(details, true)
+        if (target) target.focus()
         event.preventDefault()
       }
       break
     case 'p':
       if (ctrlBindings && event.ctrlKey) {
-        sibling(details, false).focus()
+        target = sibling(details, false)
+        if (target) target.focus()
         event.preventDefault()
       }
       break

--- a/index.js
+++ b/index.js
@@ -124,34 +124,41 @@ function keydown(event: KeyboardEvent) {
   // Ignore key presses from nested details.
   if (details.querySelector('details[open]')) return
 
-  let target
   switch (event.key) {
     case 'Escape':
       close(details)
       event.preventDefault()
       break
     case 'ArrowDown':
-      target = sibling(details, true)
-      if (target) target.focus()
-      event.preventDefault()
-      break
-    case 'ArrowUp':
-      target = sibling(details, false)
-      if (target) target.focus()
-      event.preventDefault()
-      break
-    case 'n':
-      if (ctrlBindings && event.ctrlKey) {
-        target = sibling(details, true)
+      {
+        const target = sibling(details, true)
         if (target) target.focus()
         event.preventDefault()
       }
       break
-    case 'p':
-      if (ctrlBindings && event.ctrlKey) {
-        target = sibling(details, false)
+    case 'ArrowUp':
+      {
+        const target = sibling(details, false)
         if (target) target.focus()
         event.preventDefault()
+      }
+      break
+    case 'n':
+      {
+        if (ctrlBindings && event.ctrlKey) {
+          const target = sibling(details, true)
+          if (target) target.focus()
+          event.preventDefault()
+        }
+      }
+      break
+    case 'p':
+      {
+        if (ctrlBindings && event.ctrlKey) {
+          const target = sibling(details, false)
+          if (target) target.focus()
+          event.preventDefault()
+        }
       }
       break
     case ' ':

--- a/test/test.js
+++ b/test/test.js
@@ -215,6 +215,38 @@ describe('details-menu element', function() {
     })
   })
 
+  describe('with no valid menu items', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Click</summary>
+          <details-menu>
+            <button type="button" role="menuitem" aria-disabled="true">Hubot</button>
+            <button type="button" role="menuitem" disabled>Bender</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('focus stays on summary', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+
+      summary.focus()
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(summary, document.activeElement, 'summary remains focused on toggle')
+
+      details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown'}))
+      assert.equal(summary, document.activeElement, 'summary remains focused on navigation')
+    })
+  })
+
   describe('opening the menu', function() {
     beforeEach(function() {
       const container = document.createElement('div')


### PR DESCRIPTION
A menu can have only disabled menu items for valid reasons (perhaps dynamically enabled). In this case the code should just not move focus, instead of throwing an exception.

## before

![](https://cl.ly/546b4d7a0620/Screen%252520Recording%2525202018-09-04%252520at%25252004.14%252520PM.gif)

## after

![](https://cl.ly/55c5fce3d328/Screen%252520Recording%2525202018-09-04%252520at%25252004.12%252520PM.gif)