### PR TITLE
Fix checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,27 @@ Use `data-menu-button` and `data-menu-button-text` to have button text updated o
 </details>
 ```
 
+Use `label[tabindex="0"][role=menuitemradio/menuitemcheckbox]` when dealing with radio and checkbox inputs menu items. Check states of the input element and the label will be synchronized.
+
+```html
+<details>
+  <summary>Preferred robot</summary>
+  <details-menu>
+    <ul>
+      <li><label tabindex="0" role="menuitemradio">
+        <input type="radio" name="robot" value="Hubot"> Hubot
+      </label></li>
+      <li><label tabindex="0" role="menuitemradio">
+        <input type="radio" name="robot" value="Bender"> Bender
+      </label></li>
+      <li><label tabindex="0" role="menuitemradio">
+        <input type="radio" name="robot" value="BB-8"> BB-8
+      </label></li>
+    </ul>
+  </details-menu>
+</details>
+```
+
 ### Events
 
 - `details-menu-select` - An item is to be select (cancelable).

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,14 +7,40 @@
 </head>
 <body>
   <details>
-    <summary>Robots</summary>
+    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
       <ul>
-        <li><button type="button" role="menuitem">Hubot</button></li>
-        <li><button type="button" role="menuitem">Bender</button></li>
-        <li><button type="button" role="menuitem">BB-8</button></li>
+        <li><button type="button" role="menuitem" data-menu-button-text>Hubot</button></li>
+        <li><button type="button" role="menuitem" data-menu-button-text>Bender</button></li>
+        <li><button type="button" role="menuitem" data-menu-button-text>BB-8</button></li>
       </ul>
     </details-menu>
   </details>
+
+  <details>
+    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
+    <details-menu>
+      <ul>
+        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label></li>
+        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label></li>
+        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label></li>
+      </ul>
+    </details-menu>
+  </details>
+
+  <details>
+    <summary>Favorite robots</summary>
+    <details-menu>
+      <ul>
+        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label></li>
+        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label></li>
+        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label></li>
+      </ul>
+    </details-menu>
+  </details>
+
+  <script type="text/javascript">
+    document.addEventListener('details-menu-selected', e => console.log(e))
+  </script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -87,7 +87,11 @@ function clicked(event: MouseEvent) {
   if (target.closest('details') !== details) return
 
   const item = target.closest('[role^="menuitem"]')
-  if (item) commit(item, details)
+  if (item && !ignoreLabelClick(target)) commit(item, details)
+}
+
+function ignoreLabelClick(el: Element): boolean {
+  return el.tagName === 'LABEL' && !!el.querySelector('input[type=checkbox], input[type=radio]')
 }
 
 function isCheckable(el: Element): boolean {
@@ -97,13 +101,16 @@ function isCheckable(el: Element): boolean {
 
 function updateChecked(selected: Element, details: Element) {
   if (!isCheckable(selected)) return
+  const isRadio = selected.getAttribute('role') === 'menuitemradio'
+  const wasChecked = selected.getAttribute('aria-checked') === 'true'
 
-  if (selected.getAttribute('role') === 'menuitemradio') {
+  if (isRadio) {
     for (const el of details.querySelectorAll('[role="menuitemradio"]')) {
       el.setAttribute('aria-checked', 'false')
     }
   }
-  selected.setAttribute('aria-checked', 'true')
+
+  selected.setAttribute('aria-checked', isRadio || !wasChecked ? 'true' : 'false')
 }
 
 function commit(selected: Element, details: Element) {

--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ class DetailsMenuElement extends HTMLElement {
     const summary = details.querySelector('summary')
     if (summary) summary.setAttribute('aria-haspopup', 'menu')
 
-    details.addEventListener('click', clicked)
+    details.addEventListener('click', shouldCommit)
+    details.addEventListener('change', shouldCommit)
     details.addEventListener('keydown', keydown)
     details.addEventListener(
       'toggle',
@@ -76,7 +77,7 @@ function sibling(details: Element, next: boolean): ?HTMLElement {
 
 const ctrlBindings = navigator.userAgent.match(/Macintosh/)
 
-function clicked(event: MouseEvent) {
+function shouldCommit(event: Event) {
   const target = event.target
   if (!(target instanceof Element)) return
 
@@ -86,31 +87,19 @@ function clicked(event: MouseEvent) {
   // Ignore clicks from nested details.
   if (target.closest('details') !== details) return
 
-  const item = target.closest('[role^="menuitem"]')
-  if (item && !ignoreLabelClick(target)) commit(item, details)
+  const menuitem =
+    event.type === 'click'
+      ? target.closest('[role="menuitem"]')
+      : target.closest('[role="menuitemradio"], [role="menuitemcheckbox"]')
+  if (menuitem) commit(menuitem, details)
 }
 
-function ignoreLabelClick(el: Element): boolean {
-  return el.tagName === 'LABEL' && !!el.querySelector('input[type=checkbox], input[type=radio]')
-}
-
-function isCheckable(el: Element): boolean {
-  const role = el.getAttribute('role')
-  return role === 'menuitemradio' || role === 'menuitemcheckbox'
-}
-
-function updateChecked(selected: Element, details: Element) {
-  if (!isCheckable(selected)) return
-  const isRadio = selected.getAttribute('role') === 'menuitemradio'
-  const wasChecked = selected.getAttribute('aria-checked') === 'true'
-
-  if (isRadio) {
-    for (const el of details.querySelectorAll('[role="menuitemradio"]')) {
-      el.setAttribute('aria-checked', 'false')
-    }
+function updateChecked(details: Element) {
+  for (const el of details.querySelectorAll('[role="menuitemradio"], [role="menuitemcheckbox"]')) {
+    const input = el.querySelector('input[type="radio"], input[type="checkbox"]')
+    if (!(input instanceof HTMLInputElement)) continue
+    el.setAttribute('aria-checked', input.checked.toString())
   }
-
-  selected.setAttribute('aria-checked', isRadio || !wasChecked ? 'true' : 'false')
 }
 
 function commit(selected: Element, details: Element) {
@@ -120,7 +109,7 @@ function commit(selected: Element, details: Element) {
   if (!dispatched) return
 
   updateLabel(selected, details)
-  updateChecked(selected, details)
+  updateChecked(details)
   if (selected.getAttribute('role') !== 'menuitemcheckbox') close(details)
   selected.dispatchEvent(new CustomEvent('details-menu-selected', {bubbles: true}))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -182,7 +182,7 @@ describe('details-menu element', function() {
     })
   })
 
-  describe('menu item checkboxes', function() {
+  describe('with buttons as menu item checkboxes', function() {
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `
@@ -212,6 +212,48 @@ describe('details-menu element', function() {
       assert(details.open, 'menu stays open')
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 2)
+    })
+  })
+
+  describe('with labels as menu item checkboxes', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Click</summary>
+          <details-menu>
+            <label tabindex="0" role="menuitemcheckbox" aria-checked="false"><input type="checkbox" name="robot"> Hubot</label>
+            <label tabindex="0" role="menuitemcheckbox" aria-checked="true"><input type="checkbox" name="robot" checked> Bender</label>
+            <label tabindex="0" role="menuitemcheckbox" aria-checked="false"><input type="checkbox" name="robot"> BB-8</label>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('manages checked state and fires events', function() {
+      const details = document.querySelector('details')
+      const summary = document.querySelector('summary')
+      const item = details.querySelector('label')
+      let eventCounter = 0
+      details.addEventListener('details-menu-selected', () => eventCounter++)
+
+      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open, 'menu opens')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert(details.open, 'menu stays open')
+      assert.equal(item.getAttribute('aria-checked'), 'true')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 2)
+
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(item.getAttribute('aria-checked'), 'false')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
+
+      assert.equal(eventCounter, 2, 'selected event is fired twice')
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -159,9 +159,9 @@ describe('details-menu element', function() {
         <details>
           <summary>Click</summary>
           <details-menu>
-            <button type="button" role="menuitemradio" aria-checked="false">Hubot</button>
-            <button type="button" role="menuitemradio" aria-checked="false">Bender</button>
-            <button type="button" role="menuitemradio" aria-checked="false">BB-8</button>
+            <label tabindex="0" role="menuitemradio" aria-checked="false"><input value="Hubot" name="robot" type="radio"> Hubot</label>
+            <label tabindex="0" role="menuitemradio" aria-checked="false"><input value="Bender" name="robot" type="radio"> Bender</label>
+            <label tabindex="0" role="menuitemradio" aria-checked="false"><input value="BB-8" name="robot" type="radio"> BB-8</label>
           </details-menu>
         </details>
       `
@@ -174,44 +174,11 @@ describe('details-menu element', function() {
 
     it('manages checked state', function() {
       const details = document.querySelector('details')
-      const item = details.querySelector('button')
+      const item = details.querySelector('label')
       assert.equal(item.getAttribute('aria-checked'), 'false')
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
-    })
-  })
-
-  describe('with buttons as menu item checkboxes', function() {
-    beforeEach(function() {
-      const container = document.createElement('div')
-      container.innerHTML = `
-        <details>
-          <summary>Click</summary>
-          <details-menu>
-            <button type="button" role="menuitemcheckbox" aria-checked="false">Hubot</button>
-            <button type="button" role="menuitemcheckbox" aria-checked="true">Bender</button>
-            <button type="button" role="menuitemcheckbox" aria-checked="false">BB-8</button>
-          </details-menu>
-        </details>
-      `
-      document.body.append(container)
-    })
-
-    afterEach(function() {
-      document.body.innerHTML = ''
-    })
-
-    it('manages checked state and menu stays open', function() {
-      const details = document.querySelector('details')
-      const summary = document.querySelector('summary')
-      const item = details.querySelector('button')
-      summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
-      assert(details.open, 'menu opens')
-      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
-      assert(details.open, 'menu stays open')
-      assert.equal(item.getAttribute('aria-checked'), 'true')
-      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 2)
     })
   })
 


### PR DESCRIPTION
## Problems

`details-menu` supports `role=menuitemcheckbox`, and we started to use this markup to leverage native label/input checking behavior:

```html
<label tabindex="0" role="menuitemcheckbox" aria-checked="true">
  <input type="checkbox" checked> Menu item
</label>
```

I noticed two issues when we use this markup:

1. `details-menu-select` event is fired twice on label click
   > When a `<label>` is clicked or tapped and it is associated with a form control, **the resulting click event is also raised for the associated control**. [(ref)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#Usage_notes)

2. `aria-checked` is always true (even when checkbox is unchecked)

   On select, `aria-checked` is hardcoded to be `true` instead of toggling.

See the failed test cases for reproduction steps.

## Solutions

1. Ignore click event on the label when it contains a checkbox or radio. We will rely on the subsequent click event on the input instead.

2. If item is `menuitemcheckbox`, toggle the value instead of always setting to `true`. For `menuitemradio` it stays as `true` because native input radios can't be unchecked.

---

Anyone has strong feelings on if we should enforce `menuitemcheckbox` items to contain an `input`? Listening for a `change` event on those items would be much more robust, and will prevent the possibility of input check state & `aria-checked` getting out of sync. Currently it is possible (as marked up in the test) to use `<button role="menuitemcheckbox">` without an `<input>`. 

I fear if it might be a bit too opinionated, but at the same time I don't see how we(github/github) would ever need `<button role="menuitemcheckbox">`. 