### PR TITLE
Support buttons as menuitemradio

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -38,6 +38,17 @@
     </details-menu>
   </details>
 
+  <details>
+    <summary data-menu-button>Favorite robots</summary>
+    <details-menu>
+      <ul>
+        <li><button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button></li>
+        <li><button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button></li>
+        <li><button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button></li>
+      </ul>
+    </details-menu>
+  </details>
+
   <script type="text/javascript">
     document.addEventListener('details-menu-selected', e => console.log(e))
   </script>

--- a/index.js
+++ b/index.js
@@ -88,17 +88,16 @@ function shouldCommit(event: Event) {
   if (target.closest('details') !== details) return
 
   const menuitem =
-    event.type === 'click'
-      ? target.closest('[role="menuitem"]')
-      : target.closest('[role="menuitemradio"], [role="menuitemcheckbox"]')
+    event.type === 'change'
+      ? target.closest('[role="menuitemradio"], [role="menuitemcheckbox"]')
+      : target.closest('[role="menuitem"], [role="menuitemradio"]')
   if (menuitem) commit(menuitem, details)
 }
 
-function updateChecked(details: Element) {
+function updateChecked(selected: Element, details: Element) {
   for (const el of details.querySelectorAll('[role="menuitemradio"], [role="menuitemcheckbox"]')) {
     const input = el.querySelector('input[type="radio"], input[type="checkbox"]')
-    if (!(input instanceof HTMLInputElement)) continue
-    el.setAttribute('aria-checked', input.checked.toString())
+    el.setAttribute('aria-checked', (input instanceof HTMLInputElement ? input.checked : el === selected).toString())
   }
 }
 
@@ -109,7 +108,7 @@ function commit(selected: Element, details: Element) {
   if (!dispatched) return
 
   updateLabel(selected, details)
-  updateChecked(details)
+  updateChecked(selected, details)
   if (selected.getAttribute('role') !== 'menuitemcheckbox') close(details)
   selected.dispatchEvent(new CustomEvent('details-menu-selected', {bubbles: true}))
 }

--- a/test/test.js
+++ b/test/test.js
@@ -152,7 +152,37 @@ describe('details-menu element', function() {
     })
   })
 
-  describe('mutually exclusive menu items', function() {
+  describe('mutually exclusive menu items as buttons', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Click</summary>
+          <details-menu>
+            <button type="button" role="menuitemradio" aria-checked="false">Hubot</button>
+            <button type="button" role="menuitemradio" aria-checked="false">Bender</button>
+            <button type="button" role="menuitemradio" aria-checked="false">BB-8</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('manages checked state', function() {
+      const details = document.querySelector('details')
+      const item = details.querySelector('button')
+      assert.equal(item.getAttribute('aria-checked'), 'false')
+      item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
+      assert.equal(item.getAttribute('aria-checked'), 'true')
+      assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
+    })
+  })
+
+  describe('mutually exclusive menu items as labels', function() {
     beforeEach(function() {
       const container = document.createElement('div')
       container.innerHTML = `


### PR DESCRIPTION
In #16 I added `label > input` markup constraint to `menuitemradio` and `menuitemcheckbox`. However we later found out that there are many cases of `<button type="submit" role="menuitemradio" name="type" value="csv">` which acts like radio buttons but submits without refreshing the page.

This adds support for these buttons, but keep the constraint for `menuitemcheckbox` as checkbox states are more flexible than radios. For example, with named radio inputs, we can assume all items but the selected one is unchecked, but that is not the case for checkbox inputs.