### PR TITLE
Open menu and focus item on arrow navigation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 GitHub, Inc.
+Copyright (c) 2018-2019 GitHub, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ function commit(selected: Element, details: Element) {
 
 function keydown(event: KeyboardEvent) {
   const details: any = event.currentTarget
+  const isSummaryFocused = event.target instanceof Element && event.target.tagName === 'SUMMARY'
 
   // Ignore key presses from nested details.
   if (details.querySelector('details[open]')) return
@@ -126,6 +127,9 @@ function keydown(event: KeyboardEvent) {
       break
     case 'ArrowDown':
       {
+        if (isSummaryFocused && !details.hasAttribute('open')) {
+          details.setAttribute('open', '')
+        }
         const target = sibling(details, true)
         if (target) target.focus()
         event.preventDefault()
@@ -133,6 +137,9 @@ function keydown(event: KeyboardEvent) {
       break
     case 'ArrowUp':
       {
+        if (isSummaryFocused && !details.hasAttribute('open')) {
+          details.setAttribute('open', '')
+        }
         const target = sibling(details, false)
         if (target) target.focus()
         event.preventDefault()

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,30 @@ describe('details-menu element', function() {
       assert.equal(summary, document.activeElement, 'escape focuses summary')
     })
 
+    it('opens and focuses first item on arrow down', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+
+      summary.focus()
+      assert(!details.open, 'menu is not open')
+      summary.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}))
+      assert(details.open, 'menu is open')
+      const first = details.querySelector('[role="menuitem"]')
+      assert.equal(first, document.activeElement, 'arrow focuses first item')
+    })
+
+    it('opens and focuses last item on arrow up', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+
+      summary.focus()
+      assert(!details.open, 'menu is not open')
+      summary.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}))
+      assert(details.open, 'menu is open')
+      const last = [...details.querySelectorAll('[role="menuitem"]:not([disabled]):not([aria-disabled])')].pop()
+      assert.equal(last, document.activeElement, 'arrow focuses last item')
+    })
+
     it('updates the button label with text', function() {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')


### PR DESCRIPTION
Adds up and down arrow navigation on closed menu buttons according to the WAI-ARIA [keyboard navigation recommendations](https://www.w3.org/TR/wai-aria-practices/#menubutton).

> (Optional) Down Arrow: opens the menu and moves focus to the first menu item.
> (Optional) Up Arrow: opens the menu and moves focus to the last menu item.