### PR TITLE
Remove event listeners when element is disconnected

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,21 +27,26 @@ class DetailsMenuElement extends HTMLElement {
     details.addEventListener('click', shouldCommit)
     details.addEventListener('change', shouldCommit)
     details.addEventListener('keydown', keydown)
-    details.addEventListener(
-      'toggle',
-      () => {
-        if (!this.src) return
-        const loader: any = this.querySelector('include-fragment')
-        if (loader) {
-          loader.addEventListener('loadend', focusInput.bind(null, details))
-          loader.src = this.src
-        }
-      },
-      {once: true}
-    )
-
+    details.addEventListener('toggle', loadFragment, {once: true})
     details.addEventListener('toggle', closeCurrentMenu)
     details.addEventListener('toggle', focusInput.bind(null, details))
+  }
+}
+
+function loadFragment(event) {
+  const details = event.currentTarget
+  if (!(details instanceof Element)) return
+
+  const menu = details.querySelector('details-menu')
+  if (!menu) return
+
+  const src = menu.getAttribute('src')
+  if (!src) return
+
+  const loader = menu.querySelector('include-fragment')
+  if (loader) {
+    loader.addEventListener('loadend', focusInput.bind(null, details))
+    loader.setAttribute('src', src)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -154,7 +154,8 @@ function commit(selected: Element, details: Element) {
 }
 
 function keydown(event: KeyboardEvent) {
-  const details: any = event.currentTarget
+  const details = event.currentTarget
+  if (!(details instanceof Element)) return
   const isSummaryFocused = event.target instanceof Element && event.target.tagName === 'SUMMARY'
 
   // Ignore key presses from nested details.
@@ -223,7 +224,7 @@ function isMenuItem(el: Element): boolean {
 }
 
 function close(details: Element) {
-  ;(details: any).open = false
+  details.removeAttribute('open')
   const summary = details.querySelector('summary')
   if (summary) summary.focus()
 }


### PR DESCRIPTION
Cleans up event listeners when the `<details-menu>` element is disconnected from the tree. It could be reparented under a new `<details>` element or garbage collected.