### PR TITLE
Fetch deferred menu content on mouse hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Menu content can be loaded from a server by embedding an
 ```html
 <details>
   <summary>Robots</summary>
-  <details-menu src="/robots">
+  <details-menu src="/robots" preload>
     <include-fragment>Loading…</include-fragment>
   </details-menu>
 </details>
@@ -86,6 +86,10 @@ Menu content can be loaded from a server by embedding an
 
 The `src` attribute value is copied to the `<include-fragment>` the first
 time the `<details>` button is toggled open, which starts the server fetch.
+
+If the `preload` attribute is present, the server fetch will begin on mouse
+hover over the `<details>` button, so the content may be loaded by the time
+the menu is opened.
 
 ## Browser support
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,18 @@ class DetailsMenuElement extends HTMLElement {
     super()
   }
 
+  get preload(): boolean {
+    return this.hasAttribute('preload')
+  }
+
+  set preload(value: boolean) {
+    if (value) {
+      this.setAttribute('preload', '')
+    } else {
+      this.removeAttribute('preload')
+    }
+  }
+
   get src(): string {
     return this.getAttribute('src') || ''
   }
@@ -27,6 +39,9 @@ class DetailsMenuElement extends HTMLElement {
     details.addEventListener('keydown', keydown)
     details.addEventListener('toggle', loadFragment, {once: true})
     details.addEventListener('toggle', closeCurrentMenu)
+    if (this.preload) {
+      details.addEventListener('mouseover', loadFragment, {once: true})
+    }
 
     const subscriptions = [focusOnOpen(details)]
     states.set(this, {details, subscriptions})
@@ -47,12 +62,13 @@ class DetailsMenuElement extends HTMLElement {
     details.removeEventListener('keydown', keydown)
     details.removeEventListener('toggle', loadFragment, {once: true})
     details.removeEventListener('toggle', closeCurrentMenu)
+    details.removeEventListener('mouseover', loadFragment, {once: true})
   }
 }
 
 const states = new WeakMap()
 
-function loadFragment(event) {
+function loadFragment(event: Event) {
   const details = event.currentTarget
   if (!(details instanceof Element)) return
 
@@ -63,7 +79,7 @@ function loadFragment(event) {
   if (!src) return
 
   const loader = menu.querySelector('include-fragment')
-  if (loader) {
+  if (loader && !loader.hasAttribute('src')) {
     loader.addEventListener('loadend', () => autofocus(details))
     loader.setAttribute('src', src)
   }

--- a/index.js.flow
+++ b/index.js.flow
@@ -1,6 +1,8 @@
 /* @flow */
 
 declare class DetailsMenuElement extends HTMLElement {
+  get preload(): boolean;
+  set preload(value: boolean): void;
   get src(): string;
   set src(url: string): void;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -413,4 +413,48 @@ describe('details-menu element', function() {
       assert(parent.open)
     })
   })
+
+  describe('deferred loading menu content', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Menu 1</summary>
+          <details-menu src="/test" preload>
+            <include-fragment>
+              Loading…
+            </include-fragment>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('fetches content on toggle', function() {
+      const details = document.querySelector('details')
+      const loader = details.querySelector('include-fragment')
+
+      assert(!loader.hasAttribute('src'))
+
+      details.open = true
+      details.dispatchEvent(new CustomEvent('toggle'))
+
+      assert.equal('/test', loader.getAttribute('src'))
+    })
+
+    it('fetches content on hover', function() {
+      const details = document.querySelector('details')
+      const loader = details.querySelector('include-fragment')
+
+      assert(!loader.hasAttribute('src'))
+
+      details.dispatchEvent(new CustomEvent('mouseover'))
+
+      assert.equal('/test', loader.getAttribute('src'))
+    })
+  })
 })


### PR DESCRIPTION
Adds a boolean preload attribute to load deferred menu content on mouse hover, improving perceived performance.