### PR TITLE
Preload only one <include-fragment>

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class DetailsMenuElement extends HTMLElement {
     }
 
     const subscriptions = [focusOnOpen(details)]
-    states.set(this, {details, subscriptions, preloaded: false})
+    states.set(this, {details, subscriptions, loaded: false})
   }
 
   disconnectedCallback() {
@@ -81,8 +81,8 @@ function loadFragment(event: Event) {
   const state = states.get(menu)
   if (!state) return
 
-  if (state.preloaded) return
-  state.preloaded = true
+  if (state.loaded) return
+  state.loaded = true
 
   const loader = menu.querySelector('include-fragment')
   if (loader && !loader.hasAttribute('src')) {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class DetailsMenuElement extends HTMLElement {
     }
 
     const subscriptions = [focusOnOpen(details)]
-    states.set(this, {details, subscriptions})
+    states.set(this, {details, subscriptions, preloaded: false})
   }
 
   disconnectedCallback() {
@@ -77,6 +77,12 @@ function loadFragment(event: Event) {
 
   const src = menu.getAttribute('src')
   if (!src) return
+
+  const state = states.get(menu)
+  if (!state) return
+
+  if (state.preloaded) return
+  state.preloaded = true
 
   const loader = menu.querySelector('include-fragment')
   if (loader && !loader.hasAttribute('src')) {

--- a/test/test.js
+++ b/test/test.js
@@ -456,5 +456,21 @@ describe('details-menu element', function() {
 
       assert.equal('/test', loader.getAttribute('src'))
     })
+
+    it('does not fetch nested include-fragment', function() {
+      const details = document.querySelector('details')
+      const loader = details.querySelector('include-fragment')
+
+      details.dispatchEvent(new CustomEvent('mouseover'))
+      assert.equal('/test', loader.getAttribute('src'), 'mouse hover should trigger fetch')
+
+      // Simulate include-fragment fetch.
+      const response = document.createElement('include-fragment')
+      loader.replaceWith(response)
+
+      details.open = true
+      details.dispatchEvent(new CustomEvent('toggle'))
+      assert(!response.hasAttribute('src'), 'toggle should not trigger second fetch')
+    })
   })
 })


### PR DESCRIPTION
When preloading menu content with an `<include-fragment>`, ignore any additional `<include-fragment>` children included in the server response.