### PR TITLE
Update events and docs (breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Use `label[tabindex="0"][role=menuitemradio/menuitemcheckbox]` when dealing with
 
 ### Events
 
-- `details-menu-select` (cancelable) - fired on `<details-menu>` with `event.detail.relatedTarget` being the item to be select.
+- `details-menu-select` (cancelable) - fired on `<details-menu>` with `event.detail.relatedTarget` being the item to be selected.
 - `details-menu-selected` - fired on `<details-menu>` with `event.detail.relatedTarget` being the item selected, after label is updated and menu is closed.
 
 ### Deferred loading

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Use `label[tabindex="0"][role=menuitemradio/menuitemcheckbox]` when dealing with
 
 ### Events
 
-- `details-menu-select` - An item is to be select (cancelable).
-- `details-menu-selected` - An item is selected, label updated, menu closed.
+- `details-menu-select`(cancelable) - fired on `details-menu` with `event.detail.relatedTarget` being the item to be select.
+- `details-menu-selected` - fired on `details-menu` with `event.detail.relatedTarget` being the item selected, after label is updated and menu is closed.
 
 ### Deferred loading
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Use `label[tabindex="0"][role=menuitemradio/menuitemcheckbox]` when dealing with
 
 ### Events
 
-- `details-menu-select`(cancelable) - fired on `details-menu` with `event.detail.relatedTarget` being the item to be select.
-- `details-menu-selected` - fired on `details-menu` with `event.detail.relatedTarget` being the item selected, after label is updated and menu is closed.
+- `details-menu-select` (cancelable) - fired on `<details-menu>` with `event.detail.relatedTarget` being the item to be select.
+- `details-menu-selected` - fired on `<details-menu>` with `event.detail.relatedTarget` being the item selected, after label is updated and menu is closed.
 
 ### Deferred loading
 

--- a/index.js
+++ b/index.js
@@ -185,14 +185,25 @@ function updateChecked(selected: Element, details: Element) {
 
 function commit(selected: Element, details: Element) {
   if (selected.hasAttribute('disabled') || selected.getAttribute('aria-disabled') === 'true') return
+  const menu = selected.closest('details-menu')
+  if (!menu) return
 
-  const dispatched = selected.dispatchEvent(new CustomEvent('details-menu-select', {bubbles: true, cancelable: true}))
+  const dispatched = menu.dispatchEvent(
+    new CustomEvent('details-menu-select', {
+      cancelable: true,
+      detail: {relatedTarget: selected}
+    })
+  )
   if (!dispatched) return
 
   updateLabel(selected, details)
   updateChecked(selected, details)
   if (selected.getAttribute('role') !== 'menuitemcheckbox') close(details)
-  selected.dispatchEvent(new CustomEvent('details-menu-selected', {bubbles: true}))
+  menu.dispatchEvent(
+    new CustomEvent('details-menu-selected', {
+      detail: {relatedTarget: selected}
+    })
+  )
 }
 
 function keydown(event: KeyboardEvent) {

--- a/test/test.js
+++ b/test/test.js
@@ -146,13 +146,15 @@ describe('details-menu element', function() {
       const menu = details.querySelector('details-menu')
       const item = details.querySelector('button')
 
-      menu.addEventListener('details-menu-select', () => {
+      menu.addEventListener('details-menu-select', event => {
         assert(details.open, 'menu is still open')
+        assert.equal(event.detail.relatedTarget, item)
         assert.equal(summary.textContent, 'Click')
       })
 
-      menu.addEventListener('details-menu-selected', () => {
+      menu.addEventListener('details-menu-selected', event => {
         assert(!details.open, 'menu is closed')
+        assert.equal(event.detail.relatedTarget, item)
         assert.equal(summary.textContent, 'Hubot')
         done()
       })

--- a/test/test.js
+++ b/test/test.js
@@ -143,14 +143,15 @@ describe('details-menu element', function() {
     it('fires events in order', function(done) {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')
+      const menu = details.querySelector('details-menu')
       const item = details.querySelector('button')
 
-      item.addEventListener('details-menu-select', () => {
+      menu.addEventListener('details-menu-select', () => {
         assert(details.open, 'menu is still open')
         assert.equal(summary.textContent, 'Click')
       })
 
-      item.addEventListener('details-menu-selected', () => {
+      menu.addEventListener('details-menu-selected', () => {
         assert(!details.open, 'menu is closed')
         assert.equal(summary.textContent, 'Hubot')
         done()
@@ -164,10 +165,11 @@ describe('details-menu element', function() {
     it('fires cancellable select event', function(done) {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')
+      const menu = details.querySelector('details-menu')
       const item = details.querySelector('button')
       let selectedEventCounter = 0
 
-      item.addEventListener('details-menu-select', event => {
+      menu.addEventListener('details-menu-select', event => {
         event.preventDefault()
         assert(details.open, 'menu is still open')
         assert.equal(summary.textContent, 'Click')
@@ -177,7 +179,7 @@ describe('details-menu element', function() {
         }, 0)
       })
 
-      item.addEventListener('details-menu-selected', () => {
+      menu.addEventListener('details-menu-selected', () => {
         selectedEventCounter++
       })
 
@@ -199,7 +201,7 @@ describe('details-menu element', function() {
       assert.equal(notDisabled, document.activeElement, 'arrow focuses on the last non-disabled item')
 
       const disabled = details.querySelector('[aria-disabled="true"]')
-      disabled.addEventListener('details-menu-selected', () => eventCounter++)
+      document.addEventListener('details-menu-selected', () => eventCounter++, true)
       disabled.dispatchEvent(new MouseEvent('click', {bubbles: true}))
 
       assert.equal(eventCounter, 0, 'selected event is not fired')
@@ -216,7 +218,7 @@ describe('details-menu element', function() {
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp'}))
 
       const disabled = details.querySelector('[disabled]')
-      disabled.addEventListener('details-menu-selected', () => eventCounter++)
+      document.addEventListener('details-menu-selected', () => eventCounter++, true)
       disabled.dispatchEvent(new MouseEvent('click', {bubbles: true}))
 
       assert.equal(eventCounter, 0, 'selected event is not fired')
@@ -309,7 +311,7 @@ describe('details-menu element', function() {
       const summary = document.querySelector('summary')
       const item = details.querySelector('label')
       let eventCounter = 0
-      details.addEventListener('details-menu-selected', () => eventCounter++)
+      document.addEventListener('details-menu-selected', () => eventCounter++, true)
 
       summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert(details.open, 'menu opens')


### PR DESCRIPTION
Ref: https://github.com/github/web-systems/issues/190#issuecomment-472536055

## Updates

- both events now do not bubble
- `event.detail` now contain `relatedTarget` which is the selected item

```js
document.addEventListener('details-menu-selected', event => {
  console.log(event.target) // details-menu
  console.log(event.detail.relatedTarget) // selected item
}, true)
```

## Reasoning

> When an element can contain itself as a child, like `<details>`, it makes sense to not bubble to avoid accidentally targeting the wrong element in a delegated event listener. (https://github.com/github/task-lists-element/pull/5#discussion_r266524615)

We have cases of `details-menu details-dialog details-menu` on github.com.