### PR TITLE
Fix radio input check triggering multiple details-menu-select events

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,8 +171,7 @@ function shouldCommit(event: Event) {
 
   if (event.type === 'click') {
     const menuitem = target.closest('[role="menuitem"], [role="menuitemradio"]')
-    const onlyCommitOnChangeEvent =
-      menuitem && menuitem.getAttribute('role') === 'menuitemradio' && menuitem.querySelector('input')
+    const onlyCommitOnChangeEvent = menuitem && menuitem.tagName === 'LABEL' && menuitem.querySelector('input')
     if (menuitem && !onlyCommitOnChangeEvent) {
       commit(menuitem, details)
     }

--- a/index.js
+++ b/index.js
@@ -169,11 +169,17 @@ function shouldCommit(event: Event) {
   // Ignore clicks from nested details.
   if (target.closest('details') !== details) return
 
-  const menuitem =
-    event.type === 'change'
-      ? target.closest('[role="menuitemradio"], [role="menuitemcheckbox"]')
-      : target.closest('[role="menuitem"], [role="menuitemradio"]')
-  if (menuitem) commit(menuitem, details)
+  if (event.type === 'click') {
+    const menuitem = target.closest('[role="menuitem"], [role="menuitemradio"]')
+    const onlyCommitOnChangeEvent =
+      menuitem && menuitem.getAttribute('role') === 'menuitemradio' && menuitem.querySelector('input')
+    if (menuitem && !onlyCommitOnChangeEvent) {
+      commit(menuitem, details)
+    }
+  } else if (event.type === 'change') {
+    const menuitem = target.closest('[role="menuitemradio"], [role="menuitemcheckbox"]')
+    if (menuitem) commit(menuitem, details)
+  }
 }
 
 function updateChecked(selected: Element, details: Element) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -934,8 +934,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1503,8 +1502,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1592,8 +1590,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -3225,7 +3222,6 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
-      "optional": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -3731,7 +3727,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -4022,8 +4017,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -5250,7 +5244,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
-      "optional": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -5271,7 +5264,6 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
-      "optional": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5732,8 +5724,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "yeast": {
       "version": "0.1.2",

--- a/test/test.js
+++ b/test/test.js
@@ -278,13 +278,18 @@ describe('details-menu element', function() {
       document.body.innerHTML = ''
     })
 
-    it('manages checked state', function() {
+    it('manages checked state and fires events', function() {
       const details = document.querySelector('details')
       const item = details.querySelector('label')
+      let eventCounter = 0
+      document.addEventListener('details-menu-selected', () => eventCounter++, true)
+
       assert.equal(item.getAttribute('aria-checked'), 'false')
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
+
+      assert.equal(eventCounter, 1, 'selected event is fired twice')
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -258,7 +258,7 @@ describe('details-menu element', function() {
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
-      assert.equal(eventCounter, 1, 'selected event is fired twice')
+      assert.equal(eventCounter, 1, 'selected event is fired once')
     })
   })
 
@@ -292,7 +292,7 @@ describe('details-menu element', function() {
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
-      assert.equal(eventCounter, 1, 'selected event is fired twice')
+      assert.equal(eventCounter, 1, 'selected event is fired once')
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -248,13 +248,17 @@ describe('details-menu element', function() {
       document.body.innerHTML = ''
     })
 
-    it('manages checked state', function() {
+    it('manages checked state and fires events', function() {
       const details = document.querySelector('details')
       const item = details.querySelector('button')
+      let eventCounter = 0
+      document.addEventListener('details-menu-selected', () => eventCounter++, true)
+
       assert.equal(item.getAttribute('aria-checked'), 'false')
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
+      assert.equal(eventCounter, 1, 'selected event is fired twice')
     })
   })
 
@@ -288,7 +292,6 @@ describe('details-menu element', function() {
       item.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       assert.equal(item.getAttribute('aria-checked'), 'true')
       assert.equal(details.querySelectorAll('[aria-checked="true"]').length, 1)
-
       assert.equal(eventCounter, 1, 'selected event is fired twice')
     })
   })


### PR DESCRIPTION
Fixes #28.

## Problem

https://travis-ci.org/github/details-menu-element/builds/530352904#L555-L561

Order of events:

1. Initial `<label>` `click`
2. `<input type=radio>` `click`, triggered by `<label>` `click` [per spec](https://html.spec.whatwg.org/multipage/forms.html#the-label-element)
2. `<input type=radio>` `change`

Problem occurs because all 3 of these events called `commit()`.

## Solution

When `click`, check if a `change` event should happen. If it should, ignore `click` (the first two events). 