### PR TITLE
Fix focus and role problems

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -3,49 +3,60 @@
 <head>
   <meta charset="utf-8">
   <title>details-menu demo</title>
+  <style>
+    details-menu {
+      background: white;
+      border: 1px solid;
+      display: block;
+      padding: 4px;
+      width: 200px;
+    }
+    button, label[tabindex] {
+      font-family: inherit;
+      font-size: inherit;
+      display: block;
+      background: none;
+      border: 0;
+      width: 100%;
+      text-align: left;
+      padding: 0;
+    }
+  </style>
 </head>
 <body>
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
-      <ul>
-        <li><button type="button" role="menuitem" data-menu-button-text>Hubot</button></li>
-        <li><button type="button" role="menuitem" data-menu-button-text>Bender</button></li>
-        <li><button type="button" role="menuitem" data-menu-button-text>BB-8</button></li>
-      </ul>
+      <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
+      <button type="button" role="menuitem" data-menu-button-text>Bender</button>
+      <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
     </details-menu>
   </details>
 
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
-      <ul>
-        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label></li>
-        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label></li>
-        <li><label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label></li>
-      </ul>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label>
     </details-menu>
   </details>
 
   <details>
     <summary>Favorite robots</summary>
     <details-menu>
-      <ul>
-        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label></li>
-        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label></li>
-        <li><label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label></li>
-      </ul>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label>
     </details-menu>
   </details>
 
   <details>
     <summary data-menu-button>Favorite robots</summary>
     <details-menu>
-      <ul>
-        <li><button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button></li>
-        <li><button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button></li>
-        <li><button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button></li>
-      </ul>
+        <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
+        <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+        <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
     </details-menu>
   </details>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -36,27 +36,27 @@
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
-        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label>
-        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label>
-        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label>
+      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label>
+      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label>
+      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label>
     </details-menu>
   </details>
 
   <details>
     <summary>Favorite robots</summary>
     <details-menu>
-        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label>
-        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label>
-        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label>
+      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label>
+      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label>
+      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label>
     </details-menu>
   </details>
 
   <details>
     <summary data-menu-button>Favorite robots</summary>
     <details-menu>
-        <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
-        <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
-        <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+      <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
+      <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+      <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
     </details-menu>
   </details>
 

--- a/index.js
+++ b/index.js
@@ -96,10 +96,9 @@ function focusOnOpen(details: Element) {
   const onmousedown = () => (isMouse = true)
   const onkeydown = () => (isMouse = false)
   const ontoggle = () => {
-    autofocus(details)
-    if (details.hasAttribute('open') && !isMouse) {
-      focusFirstItem(details)
-    }
+    if (!details.hasAttribute('open')) return
+    if (autofocus(details)) return
+    if (!isMouse) focusFirstItem(details)
   }
 
   details.addEventListener('mousedown', onmousedown)
@@ -128,12 +127,14 @@ function closeCurrentMenu(event: Event) {
   }
 }
 
-function autofocus(details: Element) {
-  if (!details.hasAttribute('open')) return
-
+function autofocus(details: Element): boolean {
+  if (!details.hasAttribute('open')) return false
   const input = details.querySelector('[autofocus]')
   if (input) {
     input.focus()
+    return true
+  } else {
+    return false
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -26,13 +26,16 @@ class DetailsMenuElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.setAttribute('role', 'menu')
+    if (!this.hasAttribute('role')) this.setAttribute('role', 'menu')
 
     const details = this.parentElement
     if (!details) return
 
     const summary = details.querySelector('summary')
-    if (summary) summary.setAttribute('aria-haspopup', 'menu')
+    if (summary) {
+      summary.setAttribute('aria-haspopup', 'menu')
+      if (!summary.hasAttribute('role')) summary.setAttribute('role', 'button')
+    }
 
     details.addEventListener('click', shouldCommit)
     details.addEventListener('change', shouldCommit)

--- a/test/test.js
+++ b/test/test.js
@@ -546,6 +546,51 @@ describe('details-menu element', function() {
     })
   })
 
+  describe('with input[autofocus]', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Menu 1</summary>
+          <details-menu src="/test">
+            <input autofocus>
+            <button role="menuitem">First item</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('autofocuses on input on mouse click', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const input = details.querySelector('input')
+
+      summary.focus()
+      details.open = true
+      summary.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
+      details.dispatchEvent(new CustomEvent('toggle'))
+      assert.equal(input, document.activeElement, 'mouse toggle open leaves summary focused')
+    })
+
+    it('autofocuses on input on keyboard activation', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const input = details.querySelector('input')
+
+      summary.focus()
+      details.open = true
+      summary.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter', bubbles: true}))
+      details.dispatchEvent(new CustomEvent('toggle'))
+
+      assert.equal(input, document.activeElement, 'toggle open focuses on [autofocus]')
+    })
+  })
+
   describe('closing the menu', function() {
     beforeEach(function() {
       const container = document.createElement('div')

--- a/test/test.js
+++ b/test/test.js
@@ -34,6 +34,14 @@ describe('details-menu element', function() {
       document.body.innerHTML = ''
     })
 
+    it('has default attributes set', function() {
+      const details = document.querySelector('details')
+      const summary = details.querySelector('summary')
+      const menu = details.querySelector('details-menu')
+      assert.equal(summary.getAttribute('role'), 'button')
+      assert.equal(menu.getAttribute('role'), 'menu')
+    })
+
     it('opens and does not focus an item on mouse click', function() {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')

--- a/test/test.js
+++ b/test/test.js
@@ -560,9 +560,11 @@ describe('details-menu element', function() {
       container.innerHTML = `
         <details>
           <summary>Menu 1</summary>
-          <details-menu src="/test">
+          <details-menu role="none">
             <input autofocus>
-            <button role="menuitem">First item</button>
+            <div role="menu">
+              <button role="menuitem">First item</button>
+            </div>
           </details-menu>
         </details>
       `
@@ -576,12 +578,14 @@ describe('details-menu element', function() {
     it('autofocuses on input on mouse click', function() {
       const details = document.querySelector('details')
       const summary = details.querySelector('summary')
+      const menu = details.querySelector('details-menu')
       const input = details.querySelector('input')
 
       summary.focus()
       details.open = true
       summary.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
       details.dispatchEvent(new CustomEvent('toggle'))
+      assert.equal(menu.getAttribute('role'), 'none')
       assert.equal(input, document.activeElement, 'mouse toggle open leaves summary focused')
     })
 


### PR DESCRIPTION
- Respect `[autofocus]:not([role^="menuitem"])` items when menu is toggled

- Respect existing `[role]` on `<details-menu>`

- Set `role="button"` on `<summary>` ref: https://github.com/github/details-dialog-element/issues/34. 
  > Per the manner in which the summary element is exposed to Safari's Webkit (announced as "summary" but no matching ARIA role) and Blink (announced as and reported as a "DisclosureTriangle"role) these "buttons" are not discoverable when navigating by form controls or button elements with VoiceOver on macOS or iOS.

- Remove list markup from demo page– accessibility tree comparison:

|before|after|
|-|-|
|<img width="382" alt="image" src="https://user-images.githubusercontent.com/1153134/64562306-b58c6c00-d31a-11e9-8062-ee9be81007e0.png">|<img width="393" alt="image" src="https://user-images.githubusercontent.com/1153134/64562350-d3f26780-d31a-11e9-928a-b8cc9da69884.png">|
