### PR TITLE
Support selecting menu item from <input>

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ the menu is opened.
 <details>
   <summary>Robots</summary>
   <details-menu input="filter-robots">
-    <input id="filter-robots">
-    <div role="menu">
-      <button role="menuitem">Bender</button>
-      <button role="menuitem">Hubot</button>
-      <button role="menuitem">R2-D2</button>
+    <input id="filter-robots" aria-owns="menu-container">
+    <div role="menu" id="menu-container">
+      <button role="menuitem" id="Bender">Bender</button>
+      <button role="menuitem" id="Hubot">Hubot</button>
+      <button role="menuitem" id="R2-D2">R2-D2</button>
     </div>
   </details-menu>
 </details>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ If the `preload` attribute is present, the server fetch will begin on mouse
 hover over the `<details>` button, so the content may be loaded by the time
 the menu is opened.
 
+### Focus management via `<input>`
+
+```html
+<details>
+  <summary>Robots</summary>
+  <details-menu input="filter-robots">
+    <input id="filter-robots">
+    <div role="menu">
+      <button role="menuitem">Bender</button>
+      <button role="menuitem">Hubot</button>
+      <button role="menuitem">R2-D2</button>
+    </div>
+  </details-menu>
+</details>
+```
+
+The `input` attribute changes the keyboard navigation behavior of the menu. While navigating menu items with arrow keys, the input will retain focus.
+
+Focus state can be styled with `[aria-selected="true"]`.
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/examples/index.html
+++ b/examples/index.html
@@ -69,8 +69,8 @@
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu input="filter-input">
-      <input id="filter-input" type="text" autofocus>
-      <div role="menu">
+      <input id="filter-input" type="text" autofocus aria-owns="filter-menu">
+      <div role="menu" id="filter-menu">
         <button type="button" role="menuitem" data-menu-button-text id="Hubot">Hubot</button>
         <button type="button" role="menuitem" data-menu-button-text id="Bender">Bender</button>
         <button type="button" role="menuitem" data-menu-button-text id="BB-8">BB-8</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -61,7 +61,7 @@
   </details>
 
   <script type="text/javascript">
-    document.addEventListener('details-menu-selected', e => console.log(e))
+    document.addEventListener('details-menu-selected', e => console.log(e), true)
   </script>
   <!-- <script src="../dist/index.umd.js"></script> -->
   <script type="text/javascript" src="https://unpkg.com/@github/details-menu-element@latest"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -71,9 +71,9 @@
     <details-menu input="filter-input">
       <input id="filter-input" type="text" autofocus>
       <div role="menu">
-        <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
-        <button type="button" role="menuitem" data-menu-button-text>Bender</button>
-        <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
+        <button type="button" role="menuitem" data-menu-button-text id="Hubot">Hubot</button>
+        <button type="button" role="menuitem" data-menu-button-text id="Bender">Bender</button>
+        <button type="button" role="menuitem" data-menu-button-text id="BB-8">BB-8</button>
       </div>
     </details-menu>
   </details>

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,6 +34,7 @@
   </style>
 </head>
 <body>
+  <p>Menu with plain buttons.</p>
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
@@ -43,6 +44,7 @@
     </details-menu>
   </details>
 
+  <p>Menu with radio menu items.</p>
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
@@ -52,6 +54,7 @@
     </details-menu>
   </details>
 
+  <p>Menu with checkbox menu items.</p>
   <details>
     <summary>Favorite robots</summary>
     <details-menu>
@@ -61,14 +64,7 @@
     </details-menu>
   </details>
 
-  <details>
-    <summary data-menu-button>Favorite robots</summary>
-    <details-menu>
-      <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
-      <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
-      <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
-    </details-menu>
-  </details>
+  <p>Menu with navigation from input support.</p>
 
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,6 +4,11 @@
   <meta charset="utf-8">
   <title>details-menu demo</title>
   <style>
+    details-menu [role][aria-selected="true"],
+    details-menu [role]:focus {
+      background: blue;
+      color: white;
+    }
     details-menu {
       background: white;
       border: 1px solid;
@@ -20,6 +25,11 @@
       width: 100%;
       text-align: left;
       padding: 0;
+    }
+    input[type="text"] {
+      box-sizing: border-box;
+      margin-bottom: 4px;
+      width: 100%;
     }
   </style>
 </head>
@@ -57,6 +67,18 @@
       <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
       <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
       <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+    </details-menu>
+  </details>
+
+  <details>
+    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
+    <details-menu input="filter-input">
+      <input id="filter-input" type="text" autofocus>
+      <div role="menu">
+        <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
+        <button type="button" role="menuitem" data-menu-button-text>Bender</button>
+        <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
+      </div>
     </details-menu>
   </details>
 

--- a/index.js
+++ b/index.js
@@ -314,11 +314,12 @@ function focus(target) {
   const menu = target.closest('details-menu')
   if (!(menu instanceof DetailsMenuElement)) return
   clearFocus(menu)
+  const input = menu.input
 
-  if (menu.input && document.activeElement === menu.input) {
+  if (input && document.activeElement === input) {
     if (!target.id) target.id = `rand-${(Math.random() * 1000).toFixed(0)}`
-    menu.input.setAttribute('aria-activedescendant', target.id)
     target.setAttribute('aria-selected', 'true')
+    input.setAttribute('aria-activedescendant', target.id)
   } else {
     target.focus()
   }

--- a/index.js
+++ b/index.js
@@ -155,14 +155,14 @@ function autofocus(details: Element): boolean {
 
 // Focus first item unless an item is already focused.
 function focusFirstItem(details: Element) {
-  const selected = getCurrentFocus(details)
-  if (selected && isMenuItem(selected) && details.contains(selected)) return
+  const selected = getFocusedMenuItem(details)
+  if (selected) return
 
   const target = sibling(details, true)
   if (target) focus(target)
 }
 
-function getCurrentFocus(details: Element): ?HTMLElement {
+function getFocusedMenuItem(details: Element): ?HTMLElement {
   const menu = details.querySelector('details-menu')
   if (!(menu instanceof DetailsMenuElement)) return
   let selected = document.activeElement
@@ -170,14 +170,14 @@ function getCurrentFocus(details: Element): ?HTMLElement {
     const id = menu.input.getAttribute('aria-activedescendant')
     selected = id ? document.getElementById(id) : selected
   }
-  return selected
+  return selected && details.contains(selected) && isMenuItem(selected) ? selected : null
 }
 
 function sibling(details: Element, next: boolean): ?HTMLElement {
   const options = Array.from(
     details.querySelectorAll('[role^="menuitem"]:not([hidden]):not([disabled]):not([aria-disabled="true"])')
   )
-  const selected = getCurrentFocus(details)
+  const selected = getFocusedMenuItem(details)
   const index = options.indexOf(selected)
   const found = next ? options[index + 1] : options[index - 1]
   const def = next ? options[0] : options[options.length - 1]
@@ -299,8 +299,8 @@ function keydown(event: KeyboardEvent) {
     case ' ':
     case 'Enter':
       {
-        const selected = getCurrentFocus(details)
-        if (selected && isMenuItem(selected) && selected.closest('details') === details) {
+        const selected = getFocusedMenuItem(details)
+        if (selected) {
           event.preventDefault()
           event.stopPropagation()
           selected.click()

--- a/index.js.flow
+++ b/index.js.flow
@@ -5,6 +5,7 @@ declare class DetailsMenuElement extends HTMLElement {
   set preload(value: boolean): void;
   get src(): string;
   set src(url: string): void;
+  get input(): ?HTMLInputElement;
 }
 
 declare module '@github/details-menu-element' {

--- a/test/test.js
+++ b/test/test.js
@@ -650,4 +650,48 @@ describe('details-menu element', function() {
       assert.isFalse(dialogClosed)
     })
   })
+
+  describe('support input based navigation the menu', function() {
+    beforeEach(function() {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details open>
+          <summary data-menu-button><em>Click</em></summary>
+          <details-menu input="filter-input">
+            <input id="filter-input">
+            <button type="button" role="menuitem">Hubot</button>
+            <button type="button" role="menuitem">Bender</button>
+            <button type="button" role="menuitem">BB-8</button>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function() {
+      document.body.innerHTML = ''
+    })
+
+    it('navigate from input', function() {
+      const details = document.querySelector('details')
+      const menu = details.querySelector('details-menu')
+      const input = details.querySelector('input')
+      const items = menu.querySelectorAll('[role="menuitem"]')
+
+      assert.notOk(menu.hasAttribute('role'), 'details-menu should not have role attribute when input is set')
+
+      input.focus()
+      input.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}))
+
+      assert.equal(input, document.activeElement, 'focus stays on input')
+      assert.equal(input.getAttribute('aria-activedescendant'), items[0].id, 'activedescendant is set')
+      assert.equal(items[0].getAttribute('aria-selected'), 'true')
+
+      items[1].focus()
+
+      assert.notOk(input.hasAttribute('aria-activedescendant'), 'activedescendant is removed')
+      assert.notOk(items[0].hasAttribute('aria-selected'))
+      assert.notOk(items[1].hasAttribute('aria-selected'))
+    })
+  })
 })


### PR DESCRIPTION
Currently when a menu contains a filtering input, navigating items will take user's focus away from the input. This creates quite an annoyance when quick filtering actions are performed. 

This adds support for managing focus via `aria-activedescendant` when an input is specified on the menu element, and said input is focused. Aside from setting `input` attribute, the markup should also fulfill the following (not enforced by details-menu):

- `aria-owns` on `<input>` targeting the menu item container
- `id` and `role` on the menu item container since `role=menu` should not contain `<input>`
- Static `id` on each of the menu item (there is a dynamically generated ID, but in testing it seems AT might be slow in picking them up)
- Styling focus style with `:focus, [aria-selected="true"]`

|Keyboard|**VO w/ Safari**|
|-|-|
|![](https://cl.ly/34cfafed0667/Screen%252520Recording%2525202019-10-21%252520at%25252016.07.gif)|![](https://cl.ly/1ffb28db2136/Screen%252520Recording%2525202019-10-21%252520at%25252016.17.gif)|

References: 

- https://www.w3.org/TR/wai-aria-1.1/#aria-activedescendant for managing focus
- https://www.w3.org/TR/wai-aria-1.1/#aria-selected for conveying focus state over `:focus`

