### PR TITLE
Expose APIs for clearing focus and selecting item

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 export default class DetailsMenuElement extends HTMLElement {
   preload: boolean;
   src: string;
+  clearFocus(): void;
+  selectFocusOrFirst(): void;
 }
 
 declare global {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,17 @@ class DetailsMenuElement extends HTMLElement {
     return input instanceof HTMLInputElement ? input : null
   }
 
+  clearFocus() {
+    clearFocus(this)
+  }
+
+  selectFocusOrFirst() {
+    const details = this.parentElement
+    if (!details) return
+    const element = getFocusedMenuItem(details) || sibling(details, true)
+    if (element) element.click()
+  }
+
   connectedCallback() {
     if (!this.hasAttribute('role') && !this.hasAttribute('input')) this.setAttribute('role', 'menu')
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -6,6 +6,8 @@ declare class DetailsMenuElement extends HTMLElement {
   get src(): string;
   set src(url: string): void;
   get input(): ?HTMLInputElement;
+  clearFocus(): void;
+  selectFocusOrFirst(): void;
 }
 
 declare module '@github/details-menu-element' {


### PR DESCRIPTION
This is dependent on #38, as #38 introduced a new focus state that doesn't go away on its own. I figured this could be worth a separate discussion. 

These two functions are useful when there are scripted behaviors that alter menu items. This allows those behaviors to interact with `<details-menu>` easily, instead of getting into the implementation details of `<details-menu>`.

For example,

A filtering behavior would want to clear focus after filtering. With this change, it will be able to call `detailsMenu.clearFocus()` instead of

1. duplicating details-menu's logic for querying menu items
2. clearing focus states based on details-menu's implementation

A filtering input would want to trigger an implicit selection for the first filtered result on Enter. With this change, it will be able to invoke `detailsMenu.selectFocusOrFirst()` instead of

1. check for currently focused menu item or finding first item by duplicating details-menu's logic for querying menu items
2. simulate a click() on the item

Example:

```js
menu.addEvenetListener('menuitem-filtered', () => {
  menu.clearFocus()
})
```

```js
input.addEvenetListener('keypress', event => {
  if (event.key !== 'Enter') return
  input.closest('details-menu').selectFocusOrFirst()
})
```

Note: In this use case the current focus check in `selectFocusOrFirst` is redundant, since the input would have focus. "Focus or first" is mostly an explicit name for an implicit default.