### PR TITLE
Prevent keyboard events during text composition inside of details-menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,13 +216,12 @@ function commit(selected: Element, details: Element) {
 
 function keydown(details: Element, menu: DetailsMenuElement, event: Event) {
   if (!(event instanceof KeyboardEvent)) return
-  const state = states.get(menu)
-  if (!state) return
-  if (state.isComposing) return
-  const isSummaryFocused = event.target instanceof Element && event.target.tagName === 'SUMMARY'
-
   // Ignore key presses from nested details.
   if (details.querySelector('details[open]')) return
+  const state = states.get(menu)
+  if (!state || state.isComposing) return
+
+  const isSummaryFocused = event.target instanceof Element && event.target.tagName === 'SUMMARY'
 
   switch (event.key) {
     case 'Escape':


### PR DESCRIPTION
For reference: https://github.com/github/web-systems/issues/228.

Like #38 and #39 this aims to better support having text inputs inside of `<details-menu>`. This one can be merged independently. 

For background on this approach, refer to the research I've done when fixing https://github.com/github/combobox-nav/pull/2. (`event.isComposing` is not supported in non-Chromium Edge)

You can test this locally with an IME of your choosing and with this simple markup:

```html
  <details open>
    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
    <details-menu>
      <input autofocus>
      <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
      <button type="button" role="menuitem" data-menu-button-text>Bender</button>
      <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
    </details-menu>
  </details>
```

In the GIFs I was testing with bopomofo. You can do the same by following [Apple's instruction](https://support.apple.com/guide/chinese-input-method/zhuyin-cimzt15531/mac).

|before|after|
|-|-|
|![](https://cl.ly/35700c59ce72/Screen%252520Recording%2525202019-10-23%252520at%25252015.46.gif)|![](https://cl.ly/6afd4eb4f50c/Screen%252520Recording%2525202019-10-23%252520at%25252015.42.gif)|
|Pressing up/down arrow cancels composition and moves focus. Pressing escape closes menu.|Pressing up/down arrow starts composition. Pressing escape stops composition.|