### PR TITLE
Focus menu items with aria-activedescendant

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,26 @@ If the `preload` attribute is present, the server fetch will begin on mouse
 hover over the `<details>` button, so the content may be loaded by the time
 the menu is opened.
 
+### Focus management via `<input>`
+
+```html
+<details>
+  <summary>Robots</summary>
+  <details-menu input="filter-robots">
+    <input id="filter-robots">
+    <div role="menu">
+      <button role="menuitem">Bender</button>
+      <button role="menuitem">Hubot</button>
+      <button role="menuitem">R2-D2</button>
+    </div>
+  </details-menu>
+</details>
+```
+
+The `input` attribute changes the keyboard navigation behavior of the menu. While navigating menu items with arrow keys, the input will retain focus.
+
+Focus state can be styled with `[aria-selected="true"]`.
+
 ## Browser support
 
 Browsers without native [custom element support][support] require a [polyfill][].

--- a/examples/index.html
+++ b/examples/index.html
@@ -24,6 +24,9 @@
     [role^="menuitem"][data-menu-item-focus] {
       background: lightblue;
     }
+    [role^="menuitem"]:hover {
+      background: lightblue;
+    }
   </style>
 </head>
 <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -79,7 +79,7 @@
   </details>
 
   <script type="text/javascript">
-    document.addEventListener('details-menu-selected', e => console.log(e), true)
+    document.addEventListener('details-menu-selected', e => console.log(e), {capture: true})
   </script>
   <!-- <script src="../dist/index.umd.js"></script> -->
   <script type="text/javascript" src="https://unpkg.com/@github/details-menu-element@latest"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -30,6 +30,7 @@
   </style>
 </head>
 <body>
+  <p>Menu with plain buttons.</p>
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
@@ -39,6 +40,7 @@
     </details-menu>
   </details>
 
+  <p>Menu with radio menu items.</p>
   <details>
     <summary>Best robot: <span data-menu-button>Unknown</span></summary>
     <details-menu>
@@ -48,6 +50,7 @@
     </details-menu>
   </details>
 
+  <p>Menu with checkbox menu items.</p>
   <details>
     <summary>Favorite robots</summary>
     <details-menu>
@@ -57,14 +60,7 @@
     </details-menu>
   </details>
 
-  <details>
-    <summary data-menu-button>Favorite robots</summary>
-    <details-menu>
-      <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
-      <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
-      <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
-    </details-menu>
-  </details>
+  <p>Menu with navigation from input support.</p>
 
   <details>
     <summary data-menu-button>Filter robots</summary>

--- a/examples/index.html
+++ b/examples/index.html
@@ -79,7 +79,7 @@
   </details>
 
   <script type="text/javascript">
-    document.addEventListener('details-menu-selected', e => console.log(e))
+    document.addEventListener('details-menu-selected', e => console.log(e), true)
   </script>
   <!-- <script src="../dist/index.umd.js"></script> -->
   <script type="text/javascript" src="https://unpkg.com/@github/details-menu-element@latest"></script>

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,7 +21,7 @@
       text-align: left;
       padding: 0;
     }
-    [role^="menuitem"][data-menu-item-focus] {
+    [role^="menuitem"][aria-selected="true"] {
       background: lightblue;
     }
     [role^="menuitem"]:hover {
@@ -68,8 +68,8 @@
 
   <details>
     <summary data-menu-button>Filter robots</summary>
-    <details-menu role="none">
-      <input autofocus aria-owns="filter-menu">
+    <details-menu role="none" input="filter-input">
+      <input autofocus aria-owns="filter-menu" id="filter-input">
       <div role="menu" id="filter-menu">
         <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
         <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>

--- a/examples/index.html
+++ b/examples/index.html
@@ -21,6 +21,9 @@
       text-align: left;
       padding: 0;
     }
+    [role^="menuitem"][data-menu-item-focus] {
+      background: lightblue;
+    }
   </style>
 </head>
 <body>

--- a/examples/index.html
+++ b/examples/index.html
@@ -66,6 +66,18 @@
     </details-menu>
   </details>
 
+  <details>
+    <summary data-menu-button>Filter robots</summary>
+    <details-menu role="none">
+      <input autofocus aria-owns="filter-menu">
+      <div role="menu" id="filter-menu">
+        <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
+        <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+        <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+      </div>
+    </details-menu>
+  </details>
+
   <script type="text/javascript">
     document.addEventListener('details-menu-selected', e => console.log(e))
   </script>

--- a/index.js
+++ b/index.js
@@ -43,6 +43,8 @@ class DetailsMenuElement extends HTMLElement {
       if (!summary.hasAttribute('role')) summary.setAttribute('role', 'button')
     }
 
+    const container = this.getAttribute('role') === 'menu' ? this : this.querySelector('[role="menu"]')
+
     const subscriptions = [
       fromEvent(details, 'click', e => shouldCommit(details, this, e)),
       fromEvent(details, 'change', e => shouldCommit(details, this, e)),
@@ -57,7 +59,7 @@ class DetailsMenuElement extends HTMLElement {
       ...focusOnOpen(details, this)
     ]
 
-    states.set(this, {subscriptions, loaded: false})
+    states.set(this, {container, subscriptions, loaded: false})
   }
 
   disconnectedCallback() {
@@ -156,7 +158,11 @@ function focusFirstItem(details: Element, menu: DetailsMenuElement) {
 }
 
 function activeItem(menu: DetailsMenuElement): ?HTMLElement {
-  const id = menu.getAttribute('aria-activedescendant')
+  const state = states.get(menu)
+  const container = state ? state.container : null
+  if (!container) return
+
+  const id = container.getAttribute('aria-activedescendant')
   return id ? document.getElementById(id) : null
 }
 
@@ -237,7 +243,11 @@ function identifyItems(menu: Element) {
 }
 
 function focus(menu: DetailsMenuElement, item: HTMLElement) {
-  menu.setAttribute('aria-activedescendant', item.id)
+  const state = states.get(menu)
+  const container = state ? state.container : null
+  if (!container) return
+
+  container.setAttribute('aria-activedescendant', item.id)
   for (const el of menu.querySelectorAll('[role^=menuitem][data-menu-item-focus]')) {
     el.removeAttribute('data-menu-item-focus')
   }
@@ -247,7 +257,12 @@ function focus(menu: DetailsMenuElement, item: HTMLElement) {
 
 function clearFocus(details: Element, menu: DetailsMenuElement) {
   if (details.hasAttribute('open')) return
-  menu.removeAttribute('aria-activedescendant')
+
+  const state = states.get(menu)
+  const container = state ? state.container : null
+  if (!container) return
+
+  container.removeAttribute('aria-activedescendant')
   for (const el of menu.querySelectorAll('[role^="menuitem"][data-menu-item-focus]')) {
     el.removeAttribute('data-menu-item-focus')
   }

--- a/index.js
+++ b/index.js
@@ -38,12 +38,17 @@ class DetailsMenuElement extends HTMLElement {
     if (!details) return
 
     const summary = details.querySelector('summary')
-    if (summary) {
-      summary.setAttribute('aria-haspopup', 'menu')
-      if (!summary.hasAttribute('role')) summary.setAttribute('role', 'button')
+    if (!summary) return
+
+    summary.setAttribute('aria-haspopup', 'menu')
+    if (!summary.hasAttribute('role')) {
+      summary.setAttribute('role', 'button')
     }
 
-    const container = this.getAttribute('role') === 'menu' ? this : this.querySelector('[role="menu"]')
+    const inputId = this.getAttribute('input')
+    const input = inputId ? document.getElementById(inputId) : null
+
+    const control = input || summary
 
     const subscriptions = [
       fromEvent(details, 'click', e => shouldCommit(details, this, e)),
@@ -59,7 +64,7 @@ class DetailsMenuElement extends HTMLElement {
       ...focusOnOpen(details, this)
     ]
 
-    states.set(this, {container, subscriptions, loaded: false})
+    states.set(this, {control, subscriptions, loaded: false})
   }
 
   disconnectedCallback() {
@@ -159,10 +164,10 @@ function focusFirstItem(details: Element, menu: DetailsMenuElement) {
 
 function activeItem(menu: DetailsMenuElement): ?HTMLElement {
   const state = states.get(menu)
-  const container = state ? state.container : null
-  if (!container) return
+  const control = state ? state.control : null
+  if (!control) return
 
-  const id = container.getAttribute('aria-activedescendant')
+  const id = control.getAttribute('aria-activedescendant')
   return id ? document.getElementById(id) : null
 }
 
@@ -244,14 +249,14 @@ function identifyItems(menu: Element) {
 
 function focus(menu: DetailsMenuElement, item: HTMLElement) {
   const state = states.get(menu)
-  const container = state ? state.container : null
-  if (!container) return
+  const control = state ? state.control : null
+  if (!control) return
 
-  container.setAttribute('aria-activedescendant', item.id)
-  for (const el of menu.querySelectorAll('[role^=menuitem][data-menu-item-focus]')) {
-    el.removeAttribute('data-menu-item-focus')
+  control.setAttribute('aria-activedescendant', item.id)
+  for (const el of menu.querySelectorAll('[role^=menuitem][aria-selected]')) {
+    el.removeAttribute('aria-selected')
   }
-  item.setAttribute('data-menu-item-focus', '')
+  item.setAttribute('aria-selected', 'true')
   item.scrollIntoView({block: 'nearest'})
 }
 
@@ -259,12 +264,12 @@ function clearFocus(details: Element, menu: DetailsMenuElement) {
   if (details.hasAttribute('open')) return
 
   const state = states.get(menu)
-  const container = state ? state.container : null
-  if (!container) return
+  const control = state ? state.control : null
+  if (!control) return
 
-  container.removeAttribute('aria-activedescendant')
-  for (const el of menu.querySelectorAll('[role^="menuitem"][data-menu-item-focus]')) {
-    el.removeAttribute('data-menu-item-focus')
+  control.removeAttribute('aria-activedescendant')
+  for (const el of menu.querySelectorAll('[role^="menuitem"][aria-selected]')) {
+    el.removeAttribute('aria-selected')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -242,6 +242,7 @@ function focus(menu: DetailsMenuElement, item: HTMLElement) {
     el.removeAttribute('data-menu-item-focus')
   }
   item.setAttribute('data-menu-item-focus', '')
+  item.scrollIntoView({block: 'nearest'})
 }
 
 function clearFocus(details: Element, menu: DetailsMenuElement) {

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,7 @@ describe('details-menu element', function() {
       summary.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}))
       details.dispatchEvent(new CustomEvent('toggle'))
       assert.equal(summary, document.activeElement, 'mouse toggle open leaves summary focused')
+      assert.isNull(details.querySelector('[aria-activedescendant]'))
     })
 
     it('opens and focuses first item on summary enter', function() {
@@ -63,7 +64,8 @@ describe('details-menu element', function() {
       details.dispatchEvent(new CustomEvent('toggle'))
 
       const first = details.querySelector('[role="menuitem"]')
-      assert.equal(first, document.activeElement, 'toggle open focuses first item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, first)
     })
 
     it('opens and focuses first item on arrow down', function() {
@@ -77,7 +79,8 @@ describe('details-menu element', function() {
       assert(details.open, 'menu is open')
 
       const first = details.querySelector('[role="menuitem"]')
-      assert.equal(first, document.activeElement, 'arrow focuses first item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, first)
     })
 
     it('opens and focuses last item on arrow up', function() {
@@ -91,7 +94,8 @@ describe('details-menu element', function() {
       assert(details.open, 'menu is open')
 
       const last = [...details.querySelectorAll('[role="menuitem"]:not([disabled]):not([aria-disabled])')].pop()
-      assert.equal(last, document.activeElement, 'arrow focuses last item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, last)
     })
 
     it('navigates items with arrow keys', function() {
@@ -105,13 +109,16 @@ describe('details-menu element', function() {
       assert(rest)
 
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}))
-      assert.equal(first, document.activeElement, 'arrow down focuses first item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, first)
 
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowDown', bubbles: true}))
-      assert.equal(second, document.activeElement, 'arrow down focuses second item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, second)
 
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}))
-      assert.equal(first, document.activeElement, 'arrow up focuses first item')
+      assert.equal(summary, document.activeElement)
+      assertActiveDescendant(details, first)
     })
 
     it('closes and focuses summary on escape', function() {
@@ -220,7 +227,7 @@ describe('details-menu element', function() {
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}))
 
       const notDisabled = details.querySelectorAll('[role="menuitem"]')[2]
-      assert.equal(notDisabled, document.activeElement, 'arrow focuses on the last non-disabled item')
+      assertActiveDescendant(details, notDisabled)
 
       const disabled = details.querySelector('[aria-disabled="true"]')
       document.addEventListener('details-menu-selected', () => eventCounter++, true)
@@ -651,3 +658,8 @@ describe('details-menu element', function() {
     })
   })
 })
+
+function assertActiveDescendant(details, expected) {
+  const menu = details.querySelector('[role=menu]')
+  assert.equal(menu.getAttribute('aria-activedescendant'), expected.id)
+}


### PR DESCRIPTION
Replaces the DOM focusing of menu items with [`aria-activedescendant`](https://w3c.github.io/aria-practices/#keyboard). This allows menus to contain other focusable elements, like `<input>`, that don't lose focus while navigating menu items with arrow keys.

A menu with a filtering input at the top cannot itself be `role=menu` because it hides the input from screen readers. The following relationship is required.

```html
<details-menu role="none">
  <input>
  <div role="menu" aria-activedescendant="i1">
    <button id="i1" role="menuitem"></button>
  </div>
</details-menu>
```

Managing focus with `aria-activedescendant` requires the attribute to be attached to the `role=menu` element in order for the focused item to be announced.

This is similar to #38 but differs in that there remains only one method of focusing menu items and the menu is unaware of its contents, which may or may not include an `<input>` field.