### PR TITLE
Only trigger close if details was open

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,6 +289,8 @@ function isMenuItem(el: Element): boolean {
 }
 
 function close(details: Element) {
+  const wasOpen = details.hasAttribute('open')
+  if (!wasOpen) return
   details.removeAttribute('open')
   const summary = details.querySelector('summary')
   if (summary) summary.focus()


### PR DESCRIPTION
Reference: https://github.com/github/github/pull/133881

Issue: Menu button was focused on when one of its menuitems was triggered by a hotkey without the menu being open.

Steps to reproduce:

1. Trigger a click on a menu item without the menu being open
2. See `<summary>` gets focused

This fixes the issue by returning the `close()` call if `<details>` isn't open.

|before|after|
|-|-|
|![](https://cl.ly/e1e80499dd1a/Screen%20Recording%202020-01-29%20at%2011.39.gif)|![](https://cl.ly/590b92b1fdbf/Screen%20Recording%202020-01-29%20at%2011.39.gif)|

I didn't add a test because this would be testing that something _doesn't_ happen which can potentially be any number of things.

cc @latentflip 