### PR TITLE
Support click from nested elements

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -39,11 +39,15 @@
     <details>
       <summary>Best robot: <span data-menu-button>Unknown</span></summary>
       <details-menu>
-        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot" /> Hubot</label>
-        <label tabindex="0" role="menuitemradio" data-menu-button-text
-          ><input type="radio" name="robot" /> Bender</label
-        >
-        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot" /> BB-8</label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text>
+          <span><input type="radio" name="robot" /> Hubot</span>
+        </label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text>
+          <span><input type="radio" name="robot" /> Bender</span>
+        </label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text>
+          <span><input type="radio" name="robot" /> BB-8</span>
+        </label>
       </details-menu>
     </details>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,85 +1,90 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8">
-  <title>details-menu demo</title>
-  <style>
-    details-menu {
-      background: white;
-      border: 1px solid;
-      display: block;
-      padding: 4px;
-      width: 200px;
-    }
-    button, label[tabindex] {
-      font-family: inherit;
-      font-size: inherit;
-      display: block;
-      background: none;
-      border: 0;
-      width: 100%;
-      text-align: left;
-      padding: 0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Base examples</h1>
+  <head>
+    <meta charset="utf-8" />
+    <title>details-menu demo</title>
+    <style>
+      details-menu {
+        background: white;
+        border: 1px solid;
+        display: block;
+        padding: 4px;
+        width: 200px;
+      }
+      button,
+      label[tabindex] {
+        font-family: inherit;
+        font-size: inherit;
+        display: block;
+        background: none;
+        border: 0;
+        width: 100%;
+        text-align: left;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Base examples</h1>
 
-  <details>
-    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
-    <details-menu>
-      <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
-      <button type="button" role="menuitem" data-menu-button-text>Bender</button>
-      <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
-    </details-menu>
-  </details>
+    <details>
+      <summary>Best robot: <span data-menu-button>Unknown</span></summary>
+      <details-menu>
+        <button type="button" role="menuitem" data-menu-button-text>Hubot</button>
+        <button type="button" role="menuitem" data-menu-button-text>Bender</button>
+        <button type="button" role="menuitem" data-menu-button-text>BB-8</button>
+      </details-menu>
+    </details>
 
-  <details>
-    <summary>Best robot: <span data-menu-button>Unknown</span></summary>
-    <details-menu>
-      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Hubot</label>
-      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> Bender</label>
-      <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot"> BB-8</label>
-    </details-menu>
-  </details>
+    <details>
+      <summary>Best robot: <span data-menu-button>Unknown</span></summary>
+      <details-menu>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot" /> Hubot</label>
+        <label tabindex="0" role="menuitemradio" data-menu-button-text
+          ><input type="radio" name="robot" /> Bender</label
+        >
+        <label tabindex="0" role="menuitemradio" data-menu-button-text><input type="radio" name="robot" /> BB-8</label>
+      </details-menu>
+    </details>
 
-  <details>
-    <summary>Favorite robots</summary>
-    <details-menu>
-      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Hubot</label>
-      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> Bender</label>
-      <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot"> BB-8</label>
-    </details-menu>
-  </details>
+    <details>
+      <summary>Favorite robots</summary>
+      <details-menu>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot" /> Hubot</label>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot" /> Bender</label>
+        <label tabindex="0" role="menuitemcheckbox"><input type="checkbox" name="robot" /> BB-8</label>
+      </details-menu>
+    </details>
 
-  <details>
-    <summary data-menu-button>Favorite robots</summary>
-    <details-menu>
-      <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
-      <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
-      <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
-    </details-menu>
-  </details>
+    <details>
+      <summary data-menu-button>Favorite robots</summary>
+      <details-menu>
+        <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
+        <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+        <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+      </details-menu>
+    </details>
 
-  <h1>Autofocus example</h1>
-  <p><code>summary</code> may have <code>autofocus</code> so it's the initially focused element in the page.</p>
-  <p>Then any focusable element inside the popup can declare autofocus too, so it gets focus when the popup is opened.</p>
+    <h1>Autofocus example</h1>
+    <p><code>summary</code> may have <code>autofocus</code> so it's the initially focused element in the page.</p>
+    <p>
+      Then any focusable element inside the popup can declare autofocus too, so it gets focus when the popup is opened.
+    </p>
 
-  <details>
-    <summary data-menu-button autofocus>Autofocus picker</summary>
-    <details-menu>
-      <input type="text" autofocus />
-      <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
-      <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
-      <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
-    </details-menu>
-  </details>
+    <details>
+      <summary data-menu-button autofocus>Autofocus picker</summary>
+      <details-menu>
+        <input type="text" autofocus />
+        <button type="submit" name="robot" value="Hubot" role="menuitemradio" data-menu-button-text>Hubot</button>
+        <button type="submit" name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+        <button type="submit" name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+      </details-menu>
+    </details>
 
-  <script type="text/javascript">
-    document.addEventListener('details-menu-selected', e => console.log(e))
-  </script>
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/details-menu-element@latest?module"></script>
-</body>
+    <script type="text/javascript">
+      document.addEventListener('details-menu-selected', e => console.log(e))
+    </script>
+    <!-- <script type="module" src="../dist/index.js"></script> -->
+    <script type="module" src="https://unpkg.com/@github/details-menu-element@latest?module"></script>
+  </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,10 +172,14 @@ function shouldCommit(details: Element, event: Event) {
     const menuitem = target.closest('[role="menuitem"], [role="menuitemradio"]')
     if (!menuitem) return
 
-    // Ignore double event caused by inputs nested in labels
-    if (menuitem.tagName === 'LABEL' && target !== menuitem) return
-
     const input = menuitem.querySelector('input')
+
+    // Ignore double event caused by inputs nested in labels
+    // Known issue: This will wrongly ignore a legit click event on an already checked input,
+    // but inputs are not expected to be visible in the menu items.
+    // I've found no way to discriminate the legit event from the echo one, and we don't want to trigger the selected event twice.
+    if (menuitem.tagName === 'LABEL' && target === input) return
+
     // An input inside a label will be committed as a change event (we assume it's a radio input),
     // unless the input is already checked, so we need to commit on click (to close the popup)
     const onlyCommitOnChangeEvent = menuitem.tagName === 'LABEL' && input && !input.checked


### PR DESCRIPTION
The logic that closes the menu when clicking a checked input assumes that clicks happen on a `<label>`, but actually if the label contains other elements, that click may come from them, like a `<span>`.

So instead of comparing target with label (`menuitem`), the new approach is comparing with `input`.

I've used `npm link` to verify that this fix works in dotcom.

### Note to reviewers
Most of the changes in HTML were made by Prettier.
The only actual change is adding <span> to reproduce the issue this PR fixes.