### PR TITLE
Automatically scroll on details menu when it opens off-screen

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -85,6 +85,23 @@
       </details-menu>
     </details>
 
+    <details>
+      <summary>Scroll into view radio group</summary>
+      <details-menu scrollIntoView>
+        <ul role="radiogroup">
+          <li role="radio">
+            <label><input type="radio" name="robot" value="Hubot">Hubot</label>
+          </li>
+          <li role="radio">
+            <label><input type="radio" name="robot" value="Bender">Bender</label>
+          </li>
+          <li role="radio">
+            <label><input type="radio" name="robot" value="BB-8">BB-8</label>
+          </li>
+        </ul>
+      </details-menu>
+    </details>
+
     <script type="text/javascript">
       document.addEventListener('details-menu-selected', e => console.log(e))
     </script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ class DetailsMenuElement extends HTMLElement {
       fromEvent(details, 'keydown', e => keydown(details, this, e)),
       fromEvent(details, 'toggle', () => loadFragment(details, this), {once: true}),
       fromEvent(details, 'toggle', () => closeCurrentMenu(details)),
+      fromEvent(details, 'toggle', () => scrollIntoView(details)),
       this.preload
         ? fromEvent(details, 'mouseover', () => loadFragment(details, this), {once: true})
         : NullSubscription,
@@ -135,6 +136,22 @@ function autofocus(details: Element): boolean {
   } else {
     return false
   }
+}
+
+// Scroll entire details menu into view, center on it.
+function scrollIntoView(details: Element): boolean {
+  if (!details.hasAttribute('open')) return false
+  const detailsMenu = details.querySelector<HTMLElement>('details-menu [scrollIntoView]')
+  if (detailsMenu) {
+    const innerMenu = detailsMenu.closest('[role="menu"], [role="radiogroup"]')
+    if (innerMenu) {
+      innerMenu.scrollIntoView({behavior: 'smooth', block: 'center'})
+    } else {
+      return false
+    }
+    return true
+  }
+  return false
 }
 
 // Focus first item unless an item is already focused.

--- a/test/test.js
+++ b/test/test.js
@@ -629,6 +629,45 @@ describe('details-menu element', function () {
     })
   })
 
+  describe('with input[scrollIntoView]', function () {
+    beforeEach(function () {
+      const container = document.createElement('div')
+      container.innerHTML = `
+        <details>
+          <summary>Scroll into view radio group</summary>
+          <details-menu scrollIntoView>
+            <ul role="radiogroup">
+              <li role="radio">
+                <label><input type="radio" name="robot" value="Hubot">Hubot</label>
+              </li>
+              <li role="radio">
+                <label><input type="radio" name="robot" value="Bender">Bender</label>
+              </li>
+              <li role="radio">
+                <label><input type="radio" name="robot" value="BB-8">BB-8</label>
+              </li>
+            </ul>
+          </details-menu>
+        </details>
+      `
+      document.body.append(container)
+    })
+
+    afterEach(function () {
+      document.body.innerHTML = ''
+    })
+
+    it('scrolls the inner menu into view on mouse click', function () {
+      const details = document.querySelector('details')
+      const detailsMenu = details.querySelector('details-menu')
+      const innerMenu = detailsMenu.closest('[role="menu"]')
+
+      details.open = true
+      details.dispatchEvent(new CustomEvent('toggle'))
+      assert.equal(0, innerMenu.scrollTop)
+    })
+  })
+
   describe('closing the menu', function () {
     beforeEach(function () {
       const container = document.createElement('div')


### PR DESCRIPTION
### What are you trying to accomplish?

If the details menu button is at the bottom of the page, we don't automatically scroll the page to show you the dropdown options. 

#### Example: dismissing code scanning alerts

When you click the "Dismiss alert" button in the code scanning alerts section, it will show you a list of three options in a dropdown.

However, when the "Dismiss alert" button is at the bottom of the page, we don't automatically scroll the page to show you the dropdown options. This leads to a bad experience as users might not notice there's a dropdown or they get a cut-off view of it:

<img width="383" alt="Fix_input_to_action_by_aeisenberg_·_Pull_Request__1102_·_github_codeql-action_and_Google_Calendar_-_Week_of_June_19__2022" src="https://user-images.githubusercontent.com/1354439/175557047-9c3f2fd4-d826-4771-983b-2174cf925743.png">

### What approach did you choose and why?

To fix this, let's listen for the `open` event on the dropdown menu and scroll the menu into view when it triggers.

I initially tried doing this by adding the `autofocus` property to the dropdown as the details component comes with this out-of-the-box. Unfortunately, that didn't work because that property can only be used with `input`, while we're using a radio group.

I then experimented with adding the `autofocus` to the first or last element in the radio button list (since it's actually an input) but the scrolling was not very smooth and it didn't really centre the dropdown menu in a pleasant way.

With `scrollIntoView`, the dropdown is always centred:

https://user-images.githubusercontent.com/1354439/176162175-73407e14-d696-41c1-b10f-1ebf34733854.mov

## Testing

I've added a unit test to illustrate how this should be used.

## Documentation

I've also added an example to the examples file.

## Feedback
Any feedback welcome!

## Anything else

This also addresses: https://github.com/github/details-menu-element/issues/58

