### PR TITLE
move AOR to primer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/web-systems-reviewers
+* @github/primer-reviewers


### PR DESCRIPTION
This changes the AOR for this repository from @github/web-systems-reviewers to @github/primer-reviewers 

FR will need to add @github/primer-reviewers as admin on this repository (and remove @github/web-systems-reviewers).

Refs https://github.com/github/web-systems/issues/940