### PR TITLE
Allow arrow key navigation on aria-disabled elements

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,10 +22,14 @@
         text-align: left;
         padding: 0;
       }
+      [aria-disabled="true"] {
+        color: gray;
+      }
     </style>
   </head>
   <body>
-    <h1>Base examples</h1>
+    <h1>Examples</h1>
+    <h2>Base examples</h2>
 
     <details>
       <summary>Best robot: <span data-menu-button>Unknown</span></summary>
@@ -69,7 +73,19 @@
       </details-menu>
     </details>
 
-    <h1>Autofocus example</h1>
+    <h2>`aria-disabled="true" example</h2>
+    <p>menu items with <code>aria-disabled="true"</code> should be keyboard navigable</p>
+    <details>
+      <summary data-menu-button autofocus>Least favorite robots</summary>
+      <details-menu>
+        <input type="text" autofocus />
+        <button name="robot" value="Hubot" aria-disabled="true" role="menuitemradio" data-menu-button-text>Hubot</button>
+        <button name="robot" value="Bender" role="menuitemradio" data-menu-button-text>Bender</button>
+        <button name="robot" value="BB-8" role="menuitemradio" data-menu-button-text>BB-8</button>
+      </details-menu>
+    </details>
+
+    <h2>Autofocus example</h2>
     <p><code>summary</code> may have <code>autofocus</code> so it's the initially focused element in the page.</p>
     <p>
       Then any focusable element inside the popup can declare autofocus too, so it gets focus when the popup is opened.

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ function focusFirstItem(details: Element) {
 function sibling(details: Element, next: boolean): HTMLElement | null {
   const options = Array.from(
     details.querySelectorAll<HTMLElement>(
-      '[role^="menuitem"]:not([hidden]):not([disabled]):not([aria-disabled="true"])'
+      '[role^="menuitem"]:not([hidden])'
     )
   )
   const selected = document.activeElement

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,9 +148,7 @@ function focusFirstItem(details: Element) {
 
 function sibling(details: Element, next: boolean): HTMLElement | null {
   const options = Array.from(
-    details.querySelectorAll<HTMLElement>(
-      '[role^="menuitem"]:not([hidden])'
-    )
+    details.querySelectorAll<HTMLElement>('[role^="menuitem"]:not([hidden])')
   )
   const selected = document.activeElement
   const index = selected instanceof HTMLElement ? options.indexOf(selected) : -1

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,9 +147,7 @@ function focusFirstItem(details: Element) {
 }
 
 function sibling(details: Element, next: boolean): HTMLElement | null {
-  const options = Array.from(
-    details.querySelectorAll<HTMLElement>('[role^="menuitem"]:not([hidden])')
-  )
+  const options = Array.from(details.querySelectorAll<HTMLElement>('[role^="menuitem"]:not([hidden])'))
   const selected = document.activeElement
   const index = selected instanceof HTMLElement ? options.indexOf(selected) : -1
   const found = next ? options[index + 1] : options[index - 1]

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ function focusFirstItem(details: Element) {
 }
 
 function sibling(details: Element, next: boolean): HTMLElement | null {
-  const options = Array.from(details.querySelectorAll<HTMLElement>('[role^="menuitem"]:not([hidden])'))
+  const options = Array.from(details.querySelectorAll<HTMLElement>('[role^="menuitem"]:not([hidden]):not([disabled])'))
   const selected = document.activeElement
   const index = selected instanceof HTMLElement ? options.indexOf(selected) : -1
   const found = next ? options[index + 1] : options[index - 1]

--- a/test/test.js
+++ b/test/test.js
@@ -90,7 +90,7 @@ describe('details-menu element', function () {
       summary.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}))
       assert(details.open, 'menu is open')
 
-      const last = [...details.querySelectorAll('[role="menuitem"]:not([disabled]):not([aria-disabled])')].pop()
+      const last = [...details.querySelectorAll('[role="menuitem"]:not([disabled])')].pop()
       assert.equal(last, document.activeElement, 'arrow focuses last item')
     })
 
@@ -219,7 +219,7 @@ describe('details-menu element', function () {
       summary.dispatchEvent(new MouseEvent('click', {bubbles: true}))
       details.dispatchEvent(new KeyboardEvent('keydown', {key: 'ArrowUp', bubbles: true}))
 
-      const notDisabled = details.querySelectorAll('[role="menuitem"]')[2]
+      const notDisabled = details.querySelectorAll('[role="menuitem"]')[3]
       assert.equal(notDisabled, document.activeElement, 'arrow focuses on the last non-disabled item')
 
       const disabled = details.querySelector('[aria-disabled="true"]')
@@ -423,7 +423,6 @@ describe('details-menu element', function () {
         <details>
           <summary>Click</summary>
           <details-menu>
-            <button type="button" role="menuitem" aria-disabled="true">Hubot</button>
             <button type="button" role="menuitem" disabled>Bender</button>
           </details-menu>
         </details>


### PR DESCRIPTION
## Updates
This PR makes updates to ensure that aria-disabled menu items are arrow-key navigable. 

We discovered that a `menuitem` with `aria-disabled="true"` cannot currently be accessed with arrow key navigation, and can only be accessed through tab navigation. Even with `aria-disabled="true"`, the menu item should be reachable with arrow key navigation.


In the following video, I navigate through an example I've added to `index.html` with a menu item that includes `aria-disabled="true"`. I am able to navigate through it using arrow key nav.

https://user-images.githubusercontent.com/16447748/197544785-8bb1f81e-745c-41bc-a136-972ddaa7a5cb.mov

## Context
From our internal accessibility slack thread regarding disabled menu items:

> If used, disabled controls must be user-addressable if they make up a set.  Think items in menus, buttons on a toolbar, radios in a group, etc.  If users hear, "1 of 10", they hit Down Arrow and are then told they've jumped over some items, that's more confusing and frustrating than encountering the disabled items.

## Relevant links

- [Staff only: Slack thread](https://github.slack.com/archives/C03RM57QL64/p1666376574816619)
- [Staff only: comment on PR](https://github.com/github/github/pull/238288#issuecomment-1287311741)